### PR TITLE
Fix permissions when using a data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,7 @@ RUN /setup.sh
 ADD start-postgis.sh /start-postgis.sh
 RUN chmod 0755 /start-postgis.sh
 
-USER postgres
-CMD /start-postgis.sh
+ADD perms_wrapper.sh /perms_wrapper.sh
+RUN chmod 0755 /perms_wrapper.sh
+
+CMD /perms_wrapper.sh

--- a/perms_wrapper.sh
+++ b/perms_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# needs to be done as root:
+chown -R postgres:postgres /var/lib/postgresql
+
+# everything else needs to be done as non-root (i.e. postgres)
+sudo -u postgres /start-postgis.sh


### PR DESCRIPTION
addresses issue #6 

basically need to `chown` the `/var/lib/postgres` dir _after_ volumes have been attached by Docker at run-time, to be sure postgres can write to them
