### PR TITLE
avoid name collision of env var so default docker user can be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ sudo docker run --name "postgis" -p 25432:5432 -d -t kartoza/postgis
 You can also use the following environment variables to pass a 
 user name and password. 
 
-* -e USERNAME=<PGUSER> 
-* -e PASS=<PGPASSWORD>
+* -e POSTGRES_USER=<PGUSER> 
+* -e POSTGRES_PASS=<PGPASSWORD>
 
 These will be used to create a new superuser with
 your preferred credentials. If these are not specified then the postgresql 

--- a/commit-and-deploy.sh
+++ b/commit-and-deploy.sh
@@ -26,7 +26,7 @@ if [ ! -d $HOST_DATA_DIR ]
 then
     mkdir $HOST_DATA_DIR
 fi
-CMD="docker run -cidfile="$IDFILE" -name="postgis" -e USERNAME=$PGUSER -e PASS=$PGPASS -d -v $HOST_DATA_DIR:/var/lib/postgresql -t qgis/postgis:$VERSION /start.sh"
+CMD="docker run -cidfile="$IDFILE" -name="postgis" -e POSTGRES_USER=$PGUSER -e POSTGRES_PASS=$PGPASS -d -v $HOST_DATA_DIR:/var/lib/postgresql -t qgis/postgis:$VERSION /start.sh"
 echo 'Running:'
 echo $CMD
 eval $CMD

--- a/run-postgis-docker.sh
+++ b/run-postgis-docker.sh
@@ -65,8 +65,8 @@ docker rm ${CONTAINER_NAME}
 CMD="docker run --name="${CONTAINER_NAME}" \
         --hostname="${CONTAINER_NAME}" \
         --restart=always \
-	-e USERNAME=${PGUSER} \
-	-e PASS=${PGPASSWORD} \
+	-e POSTGRES_USER=${PGUSER} \
+	-e POSTGRES_PASS=${PGPASSWORD} \
 	-d -t \
         ${VOLUME_OPTION} \
 	kartoza/postgis /start-postgis.sh"
@@ -79,7 +79,7 @@ docker ps | grep ${CONTAINER_NAME}
 
 echo "Connect using:"
 echo "psql -l -p 5432 -h $IPADDRESS -U $PGUSER"
-echo "and password $PGPASS"
+echo "and password $PGPASSWORD"
 echo
 echo "Alternatively link to this container from another to access it"
 echo "e.g. docker run -link postgis:pg .....etc"

--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -25,9 +25,9 @@ fi
 # needs to be done as root:
 chown -R postgres:postgres $DATADIR
 
-# Note that $USERNAME and $PASS below are optional paramters that can be passed
+# Note that $POSTGRES_USER and $POSTGRES_PASS below are optional paramters that can be passed
 # via docker run e.g.
-#docker run --name="postgis" -e USERNAME=qgis -e PASS=qgis -d -v
+#docker run --name="postgis" -e POSTGRES_USER=qgis -e POSTGRES_PASS=qgis -d -v 
 #/var/docker-data/postgres-dat:/var/lib/postgresql -t qgis/postgis:6
 
 # If you dont specify a user/password in docker run, we will generate one
@@ -45,18 +45,18 @@ if [ ! "$(ls -A $DATADIR)" ]; then
 fi
 
 # Make sure we have a user set up
-if [ -z "$USERNAME" ]; then
-  USERNAME=docker
-fi
-if [ -z "$PASS" ]; then
-  PASS=docker
-fi
+if [ -z "$POSTGRES_USER" ]; then
+  POSTGRES_USER=docker
+fi  
+if [ -z "$POSTGRES_PASS" ]; then
+  POSTGRES_PASS=docker
+fi  
 # redirect user/pass into a file so we can echo it into
 # docker logs when container starts
 # so that we can tell user their password
-echo "postgresql user: $USERNAME" > /tmp/PGPASSWORD.txt
-echo "postgresql password: $PASS" >> /tmp/PGPASSWORD.txt
-su - postgres -c "$POSTGRES --single -D $DATADIR -c config_file=$CONF <<< \"CREATE USER $USERNAME WITH SUPERUSER ENCRYPTED PASSWORD '$PASS';\""
+echo "postgresql user: $POSTGRES_USER" > /tmp/PGPASSWORD.txt
+echo "postgresql password: $POSTGRES_PASS" >> /tmp/PGPASSWORD.txt
+su - postgres -c "$POSTGRES --single -D $DATADIR -c config_file=$CONF <<< \"CREATE USER $POSTGRES_USER WITH SUPERUSER ENCRYPTED PASSWORD '$POSTGRES_PASS';\""
 
 trap "echo \"Sending SIGTERM to postgres\"; killall -s SIGTERM postgres" SIGTERM
 


### PR DESCRIPTION
fix for issue #8 

I have only tested building the Dockerfile and running my own container, have not tried the other two shell scripts `run-postgis-docker.sh` and `commit-and-deploy.sh`