### PR TITLE
Fix TOPOLOGY conditional typo

### DIFF
--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -86,7 +86,7 @@ then
     if [[ ${HSTORE} == "true" ]]; then
         echo 'HSTORE is only useful when you create the postgis database.'
     fi
-    if [[] ${TOPOLOGY} == "true" ]]; then
+    if [[ ${TOPOLOGY} == "true" ]]; then
         echo 'TOPOLOGY is only useful when you create the postgis database.'
     fi
 else


### PR DESCRIPTION
I built this image, but got the following error: `db_1 | /start-postgis.sh: line 89: [[]: command not found`

And I think this minor PR fixes that error.

Here is the full output:

```
[grease-lightning]/home/.../docker-scripts/backend$ docker-compose -f smartercleanup-api-deploy.yml up
Recreating backend_db_1...
Attaching to backend_db_1
db_1 | 2015-09-02 12:19:20 UTC [20-1] LOG:  database system was interrupted; last known up at 2015-09-02 11:12:46 UTC
db_1 | 2015-09-02 12:19:20 UTC [20-2] LOG:  database system was not properly shut down; automatic recovery in progress
db_1 | 2015-09-02 12:19:20 UTC [20-3] LOG:  redo starts at 0/16A84E8
db_1 | 2015-09-02 12:19:20 UTC [20-4] LOG:  record with zero length at 0/16A8B40
db_1 | 2015-09-02 12:19:20 UTC [20-5] LOG:  redo done at 0/16A8B10
db_1 | 2015-09-02 12:19:20 UTC [20-6] LOG:  last completed transaction was at log time 2015-09-02 11:12:46.34326+00
db_1 |
db_1 | PostgreSQL stand-alone backend 9.4.3
db_1 | 2015-09-02 12:19:20 UTC [20-7] ERROR:  role "postgres" already exists
db_1 | 2015-09-02 12:19:20 UTC [20-8] STATEMENT:  CREATE USER postgres WITH SUPERUSER ENCRYPTED PASSWORD 'unicorn1234';
db_1 |
db_1 | 2015-09-02 12:19:20 UTC [27-1] LOG:  database system was shut down at 2015-09-02 12:19:20 UTC
db_1 | 2015-09-02 12:19:20 UTC [25-1] LOG:  database system is ready to accept connections
db_1 | 2015-09-02 12:19:20 UTC [31-1] LOG:  autovacuum launcher started
db_1 | Postgis Already There
db_1 | HSTORE is only useful when you create the postgis database.
db_1 | /start-postgis.sh: line 89: [[]: command not found
db_1 |                                  List of databases
db_1 |        Name       |  Owner   | Encoding  | Collate | Ctype |   Access privileges
db_1 | ------------------+----------+-----------+---------+-------+-----------------------
db_1 |  postgres         | postgres | SQL_ASCII | C       | C     |
db_1 |  template0        | postgres | SQL_ASCII | C       | C     | =c/postgres          +
db_1 |                   |          |           |         |       | postgres=CTc/postgres
db_1 |  template1        | postgres | SQL_ASCII | C       | C     | =c/postgres          +
db_1 |                   |          |           |         |       | postgres=CTc/postgres
db_1 |  template_postgis | postgres | UTF8      | C       | C     |
db_1 | (4 rows)
db_1 |
db_1 | Postgres initialisation process completed .... restarting in foreground
db_1 | 2015-09-02 12:19:30 UTC [66-1] LOG:  database system was interrupted; last known up at 2015-09-02 12:19:20 UTC
db_1 | 2015-09-02 12:19:31 UTC [66-2] LOG:  database system was not properly shut down; automatic recovery in progress
db_1 | 2015-09-02 12:19:31 UTC [66-3] LOG:  record with zero length at 0/16A8C10
db_1 | 2015-09-02 12:19:31 UTC [66-4] LOG:  redo is not required
db_1 | 2015-09-02 12:19:31 UTC [63-1] LOG:  database system is ready to accept connections
db_1 | 2015-09-02 12:19:31 UTC [70-1] LOG:  autovacuum launcher started
^CGracefully stopping... (press Ctrl+C again to force)
Stopping backend_db_1... done
```
