### PR TITLE
A couple of changes for more reliable startup of dependent apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y install ca-certificates rpl pwgen
 # The following packages have unmet dependencies:
 # postgresql-9.3-postgis-2.1 : Depends: libgdal1h (>= 1.9.0) but it is not going to be installed
 #                              Recommends: postgis but it is not going to be installed
-RUN apt-get install -y postgresql-9.4-postgis-2.1 postgis 
+RUN apt-get install -y postgresql-9.4-postgis-2.1 postgis netcat
 ADD postgres.conf /etc/supervisor/conf.d/postgres.conf
 
 # Open port 5432 so linked containers can see them


### PR DESCRIPTION
It's often the case (eg under docker-compose) where an app container needs to poll a server container to see when the server is ready to receive connections.

I had a problem with this image because it starts a temporary postgres server to do some initialisation tasks, then kills it and starts a new server.  This caused errors with my app container because it thought postgres was up and then it went away again.

For context, the problem is discussed by others here a bit:
http://stackoverflow.com/questions/28244869/creating-a-table-in-single-user-mode-in-postgres
(particularly in the comments on the original question)

So I made a change to start the temporary server listening on localhost-only.  This has fixed things for my app container.

Also, by installing `netcat` the start script can poll for the server to be ready instead of waiting 10 seconds and hoping for the best.