### PR TITLE
Use postgresql.conf file in $DATADIR

### DIFF
--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -3,7 +3,7 @@
 # This script will run as the postgres user due to the Dockerfile USER directive
 
 DATADIR="/var/lib/postgresql/9.4/main"
-CONF="/etc/postgresql/9.4/main/postgresql.conf"
+CONF="$DATADIR/postgresql.conf"
 POSTGRES="/usr/lib/postgresql/9.4/bin/postgres"
 INITDB="/usr/lib/postgresql/9.4/bin/initdb"
 SQLDIR="/usr/share/postgresql/9.4/contrib/postgis-2.1/"


### PR DESCRIPTION
Currently start-postgis.sh initializes $DATADIR if no files are present. This includes the creation of postgresql.conf and pg_hba.conf etc. but making changes to $DATADIR/pg_hba.conf (for example) has no effect, because this script referred to config files under /etc.
