### PR TITLE
upgrade postgres to 9.5 and postgis to 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN  dpkg-divert --local --rename --add /sbin/initctl
 ADD 71-apt-cacher-ng /etc/apt/apt.conf.d/71-apt-cacher-ng
 
 #RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list
+# Add the PostgreSQL PGP key to verify their Debian packages.
+# It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+# Add PostgreSQL's repository. It contains the most recent stable release
+#     of PostgreSQL, ``9.5``.
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get -y update
 RUN apt-get -y install ca-certificates rpl pwgen
 
@@ -23,7 +29,7 @@ RUN apt-get -y install ca-certificates rpl pwgen
 # The following packages have unmet dependencies:
 # postgresql-9.3-postgis-2.1 : Depends: libgdal1h (>= 1.9.0) but it is not going to be installed
 #                              Recommends: postgis but it is not going to be installed
-RUN apt-get install -y postgresql-9.4-postgis-2.1 postgis netcat
+RUN apt-get install -y postgresql-9.5-postgis-2.2 netcat
 ADD postgres.conf /etc/supervisor/conf.d/postgres.conf
 
 # Open port 5432 so linked containers can see them

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,14 @@
 # Add any additional setup tasks here
+chmod 600 /etc/ssl/private/ssl-cert-snakeoil.key
 
 # These tasks are run as root
-CONF="/etc/postgresql/9.4/main/postgresql.conf"
+CONF="/etc/postgresql/9.5/main/postgresql.conf"
 
 # Restrict subnet to docker private network
-echo "host    all             all             172.17.0.0/16               md5" >> /etc/postgresql/9.4/main/pg_hba.conf
+echo "host    all             all             172.17.0.0/16               md5" >> /etc/postgresql/9.5/main/pg_hba.conf
 # Listen on all ip addresses
-echo "listen_addresses = '*'" >> /etc/postgresql/9.4/main/postgresql.conf
-echo "port = 5432" >> /etc/postgresql/9.4/main/postgresql.conf
+echo "listen_addresses = '*'" >> /etc/postgresql/9.5/main/postgresql.conf
+echo "port = 5432" >> /etc/postgresql/9.5/main/postgresql.conf
 
 # Enable ssl
 

--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -2,11 +2,11 @@
 
 # This script will run as the postgres user due to the Dockerfile USER directive
 
-DATADIR="/var/lib/postgresql/9.4/main"
-CONF="/etc/postgresql/9.4/main/postgresql.conf"
-POSTGRES="/usr/lib/postgresql/9.4/bin/postgres"
-INITDB="/usr/lib/postgresql/9.4/bin/initdb"
-SQLDIR="/usr/share/postgresql/9.4/contrib/postgis-2.1/"
+DATADIR="/var/lib/postgresql/9.5/main"
+CONF="/etc/postgresql/9.5/main/postgresql.conf"
+POSTGRES="/usr/lib/postgresql/9.5/bin/postgres"
+INITDB="/usr/lib/postgresql/9.5/bin/initdb"
+SQLDIR="/usr/share/postgresql/9.5/contrib/postgis-2.2/"
 LOCALONLY="-c listen_addresses='127.0.0.1, ::1'"
 
 # /etc/ssl/private can't be accessed from within container for some reason
@@ -18,8 +18,8 @@ rm -r /etc/ssl
 mv /tmp/ssl-copy /etc/ssl
 
 # Needed under debian, wasnt needed under ubuntu
-mkdir /var/run/postgresql/9.4-main.pg_stat_tmp
-chmod 0777 /var/run/postgresql/9.4-main.pg_stat_tmp
+mkdir /var/run/postgresql/9.5-main.pg_stat_tmp
+chmod 0777 /var/run/postgresql/9.5-main.pg_stat_tmp
 
 # test if DATADIR is existent
 if [ ! -d $DATADIR ]; then
@@ -128,7 +128,7 @@ fi
 # This should show up in docker logs afterwards
 su - postgres -c "psql -l"
 
-PID=`cat /var/run/postgresql/9.4-main.pid`
+PID=`cat /var/run/postgresql/9.5-main.pid`
 kill -9 ${PID}
 echo "Postgres initialisation process completed .... restarting in foreground"
 SETVARS="POSTGIS_ENABLE_OUTDB_RASTERS=1 POSTGIS_GDAL_ENABLED_DRIVERS=ENABLE_ALL"


### PR DESCRIPTION
- Adds ubuntu repo for 9.5/2.2
- Changes permissions to snakeoil key so postgres 9.5 doesn't complain and abort startup
- Renames routes to 9.5/2.2
- Installs postgres 9.5 and postgis 2.2