### PR TITLE
Allow custom IP range in pg_hba.conf via docker run -e

### DIFF
--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -63,7 +63,8 @@ if [ -z "$TOPOLOGY" ]; then
   TOPOLOGY=true
 fi  
 
-# Customize IP range
+# Custom IP range via docker run -e (https://docs.docker.com/engine/reference/run/#env-environment-variables)
+# Usage is: docker run [...] -e ALLOW_IP_RANGE='192.168.0.0/16' 
 if [ "$ALLOW_IP_RANGE" ]
 then
   echo "host    all             all             $ALLOW_IP_RANGE              md5" >> /etc/postgresql/9.4/main/pg_hba.conf

--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -63,6 +63,11 @@ if [ -z "$TOPOLOGY" ]; then
   TOPOLOGY=true
 fi  
 
+# Customize IP range
+if [ "$ALLOW_IP_RANGE" ]
+then
+  echo "host    all             all             $ALLOW_IP_RANGE              md5" >> /etc/postgresql/9.4/main/pg_hba.conf
+fi
 
 # redirect user/pass into a file so we can echo it into
 # docker logs when container starts


### PR DESCRIPTION
A suggestion for issues #40, the last question in #41, and #32. This would allow custom IP ranges in pg_bha.conf using the [docker run environment variables](https://docs.docker.com/engine/reference/run/#env-environment-variables) to pass in an optional value (ALLOW_IP_RANGE). If ALLOW_IP_RANGE is passed in start-postgis.sh will use it to update pg_hba.conf. This ensures the default container is still secure but allows users more flexibility during development or if they are using tools such as docker-machine.

Usage is:
```
docker run --name "postgis" -e ALLOW_IP_RANGE='192.168.0.0/16' -p 25432:5432 -d -t postgis
```