### PR TITLE
Improve start

### DIFF
--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -18,7 +18,7 @@ rm -r /etc/ssl
 mv /tmp/ssl-copy /etc/ssl
 
 # Needed under debian, wasnt needed under ubuntu
-mkdir /var/run/postgresql/9.5-main.pg_stat_tmp
+mkdir -p /var/run/postgresql/9.5-main.pg_stat_tmp
 chmod 0777 /var/run/postgresql/9.5-main.pg_stat_tmp
 
 # test if DATADIR is existent

--- a/start-postgis.sh
+++ b/start-postgis.sh
@@ -135,7 +135,13 @@ fi
 su - postgres -c "psql -l"
 
 PID=`cat /var/run/postgresql/9.5-main.pid`
-kill -9 ${PID}
+kill -TERM ${PID}
+
+# Wait for background postgres main process to exit
+while [ "$(ls -A /var/run/postgresql/9.5-main.pid 2>/dev/null)" ]; do
+  sleep 1
+done
+
 echo "Postgres initialisation process completed .... restarting in foreground"
 SETVARS="POSTGIS_ENABLE_OUTDB_RASTERS=1 POSTGIS_GDAL_ENABLED_DRIVERS=ENABLE_ALL"
 su - postgres -c "$SETVARS $POSTGRES -D $DATADIR -c config_file=$CONF"


### PR DESCRIPTION
This replaces the killing method of the initial background process. Instead of sending a SIGKILL signal, sends a SIGTERM and wait postgres to properly shutdown, avoiding errors when tries to start the foreground process. This issue on Centos 7 was actually preventing the image to start at all, as would trigger some memory allocation errors.

