### PR TITLE
Allow configuring SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ user name, password and/or default database name(or multiple databases coma sepa
 * -e POSTGRES_PASS=<PGPASSWORD>
 * -e POSTGRES_DBNAME=<PGDBNAME>
 * -e POSTGRES_MULTIPLE_EXTENSIONS=postgis,hstore,postgis_topology # You can pass as many extensions as you need.
+* -e SSL_CERT_FILE=/your/own/ssl_cert_file.pem
+* -e SSL_KEY_FILE=/your/own/ssl_key_file.key
 
 These will be used to create a new superuser with
 your preferred credentials. If these are not specified then the postgresql 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ user name, password and/or default database name(or multiple databases coma sepa
 * -e POSTGRES_MULTIPLE_EXTENSIONS=postgis,hstore,postgis_topology # You can pass as many extensions as you need.
 * -e SSL_CERT_FILE=/your/own/ssl_cert_file.pem
 * -e SSL_KEY_FILE=/your/own/ssl_key_file.key
+* -e SSL_CA_FILE=/your/own/ssl_ca_file.pem
 
 These will be used to create a new superuser with
 your preferred credentials. If these are not specified then the postgresql 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ services:
       - SSL_KEY_FILE=/etc/ssl/private/ssl_key.pem
 ```
 
+See [the postgres documentation about SSL](https://www.postgresql.org/docs/11/libpq-ssl.html#LIBQ-SSL-CERTIFICATES) for more information.
+
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ services:
       dockerfile: Dockerfile
       context: ssl_secured_docker
     environment:
-      - ALLOW_IP_RANGE="172.18.0.0/16"
       - SSL_CERT_FILE=/etc/ssl/certs/ssl_cert.pem
       - SSL_KEY_FILE=/etc/ssl/private/ssl_key.pem
 ```

--- a/README.md
+++ b/README.md
@@ -306,6 +306,41 @@ However, you should note that this option doesn't mean anything if you didn't
 persist your database volume. Because if it is not persisted, then it will be lost 
 on restart because docker will recreate the container.
 
+## Postgres SSL setup
+
+By default the image is delivered with an unsigned SSL certificate. This helps to have an
+encrypted connection to clients and avoid eavesdropping but does not help to mitigate
+man in the middle (MITM) attacks.
+
+You need to provide your own, signed private key to avoid this kind of attacks (and make
+sure clients connect with verify-ca or verify-full sslmode).
+
+The following is an example Dockerfile that sets up a container with custom ssl private key and certificate:
+
+```
+FROM kartoza/postgis:11.0-2.5
+
+ADD ssl_cert.pem /etc/ssl/certs/ssl_cert.pem
+ADD localhost_ssl_key.pem /etc/ssl/private/ssl_key.pem
+
+RUN chmod 400 /etc/ssl/private/ssl_key.pem
+```
+
+And a docker-compose.yml to initialize with this configuration:
+
+```
+services:
+  postgres:
+    build:
+      dockerfile: Dockerfile
+      context: ssl_secured_docker
+    environment:
+      - ALLOW_IP_RANGE="172.18.0.0/16"
+      - SSL_CERT_FILE=/etc/ssl/certs/ssl_cert.pem
+      - SSL_KEY_FILE=/etc/ssl/private/ssl_key.pem
+```
+
+
 ## Credits
 
 Tim Sutton (tim@kartoza.com)

--- a/env-data.sh
+++ b/env-data.sh
@@ -54,6 +54,14 @@ if [ -z "${IP_LIST}" ]; then
 	IP_LIST='*'
 fi
 
+if [ -z "${SSL_CERT_FILE}" ]; then
+	SSL_CERT_FILE='/etc/ssl/certs/ssl-cert-snakeoil.pem'
+fi
+
+if [ -z "${SSL_KEY_FILE}" ]; then
+	SSL_KEY_FILE='/etc/ssl/private/ssl-cert-snakeoil.key'
+fi
+
 if [ -z "${POSTGRES_MULTIPLE_EXTENSIONS}" ]; then
   POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology'
 fi

--- a/setup-ssl.sh
+++ b/setup-ssl.sh
@@ -25,8 +25,8 @@ chmod 0777 ${PGSTAT_TMP}
 echo "ssl = true" >> $CONF
 #echo "ssl_ciphers = 'DEFAULT:!LOW:!EXP:!MD5:@STRENGTH' " >> $CONF
 #echo "ssl_renegotiation_limit = 512MB "  >> $CONF
-echo "ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'" >> $CONF
-echo "ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'" >> $CONF
+echo "ssl_cert_file = '${SSL_CERT_FILE}'" >> $CONF
+echo "ssl_key_file = '${SSL_KEY_FILE}'" >> $CONF
 #echo "ssl_ca_file = ''                       # (change requires restart)" >> $CONF
 #echo "ssl_crl_file = ''" >> $CONF
 

--- a/setup-ssl.sh
+++ b/setup-ssl.sh
@@ -27,7 +27,9 @@ echo "ssl = true" >> $CONF
 #echo "ssl_renegotiation_limit = 512MB "  >> $CONF
 echo "ssl_cert_file = '${SSL_CERT_FILE}'" >> $CONF
 echo "ssl_key_file = '${SSL_KEY_FILE}'" >> $CONF
-#echo "ssl_ca_file = ''                       # (change requires restart)" >> $CONF
+if [ ! -z "${SSL_CA_FILE}" ]; then
+	echo "ssl_ca_file = '${SSL_CA_FILE}'                       # (change requires restart)" >> $CONF
+fi
 #echo "ssl_crl_file = ''" >> $CONF
 
 # Put lock file to make sure conf was not reinitialized


### PR DESCRIPTION
Adds new environment variables to provide custom ssl keys and certs.
This is for early preview, I'm still testing this out in detail.

* -e SSL_CERT_FILE=/your/own/ssl_cert_file.crt
* -e SSL_KEY_FILE=/your/own/ssl_key_file.key
* -e SSL_CA_FILE=/your/own/ssl_ca_file.crt

Please note that the files have to be placed somewhere, where they are accessible for the postgres server and that the access mode for the key file has to be user only (400) or the server won't start. The pull request includes an example Dockerfile that takes docker-postgis as a base image and uploads keys and certs and ensures proper file mode and a docker-compose.yml that sets the env vars.