### PR TITLE
Extra conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ PostgreSQL listens to you can define it with the following environment variable.
 all connections.
 * -e IP_LIST=<*>
 
-You can also define other configurations to add to `postgres.conf`, separated by '\n':
+You can also define any other configuration to add to `postgres.conf`, separated by '\n' e.g.:
 
 * -e EXTRA_CONF="log_destination = 'stderr'\nlogging_collector = on"
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ PostgreSQL listens to you can define it with the following environment variable.
 all connections.
 * -e IP_LIST=<*>
 
+You can also define other configurations to add to `postgres.conf`, separated by '\n':
+
+* -e EXTRA_CONF="log_destination = 'stderr'\nlogging_collector = on"
 
 
 ## Convenience docker-compose.yml

--- a/env-data.sh
+++ b/env-data.sh
@@ -118,6 +118,11 @@ fi
 if [ -z "${REPLICATION_PASS}" ]; then
   REPLICATION_PASS=replicator
 fi
+
+if [ -z "$EXTRA_CONF" ]; then
+    EXTRA_CONF=""
+fi
+
 # Compatibility with official postgres variable
 # Official postgres variable gets priority
 if [ ! -z "${POSTGRES_PASSWORD}" ]; then

--- a/setup-conf.sh
+++ b/setup-conf.sh
@@ -36,6 +36,8 @@ checkpoint_timeout = ${CHECK_POINT_TIMEOUT}
 #archive_command = 'test ! -f ${WAL_ARCHIVE}/%f && cp -r %p ${WAL_ARCHIVE}/%f'
 EOF
 
+echo -e $EXTRA_CONF >> $CONF
+
 # Optimise PostgreSQL shared memory for PostGIS
 # shmall units are pages and shmmax units are bytes(?) equivalent to the desired shared_buffer size set in setup_conf.sh - in this case 500MB
 echo "kernel.shmmax=543252480" >> /etc/sysctl.conf


### PR DESCRIPTION
Allow to define any other configuration to be added to `postgres.conf` with the `EXTRA_CONF` environemt variable.
Useful with postgres' configurations like `logging_collector` that is not possible to set at run time.