### PR TITLE
Extensions in template1 added

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ user name, password and/or default database name(or multiple databases comma sep
 * -e DEFAULT_ENCODING="UTF8"
 * -e DEFAULT_COLLATION="en_US.UTF-8"
 * -e DEFAULT_CTYPE="en_US.UTF-8"
+  
+Specifies whether extensions will also be installed in template1 database.
+* -e POSTGRES_TEMPLATE_EXTENSIONS=true
 
 Maximum size to let the WAL grow to between automatic WAL checkpoints.
 * -e WAL_SIZE=4GB

--- a/setup-database.sh
+++ b/setup-database.sh
@@ -44,7 +44,6 @@ echo "postgres ready"
 source /setup-user.sh
 
 # enable extensions in template1 if env variable set to true
-echo $POSTGRES_TEMPLATE_EXTENSIONS
 if [ "$POSTGRES_TEMPLATE_EXTENSIONS" = true ] ; then
     for ext in $(echo ${POSTGRES_MULTIPLE_EXTENSIONS} | tr ',' ' '); do
         echo "Enabling ${ext} in the database template1"

--- a/setup-database.sh
+++ b/setup-database.sh
@@ -43,6 +43,14 @@ echo "postgres ready"
 # Setup user
 source /setup-user.sh
 
+# enable extensions in template1 if env variable set to true
+echo $POSTGRES_TEMPLATE_EXTENSIONS
+if [ "$POSTGRES_TEMPLATE_EXTENSIONS" = true ] ; then
+    for ext in $(echo ${POSTGRES_MULTIPLE_EXTENSIONS} | tr ',' ' '); do
+        echo "Enabling ${ext} in the database template1"
+        su - postgres -c "psql -c 'CREATE EXTENSION IF NOT EXISTS ${ext} cascade;' template1"
+    done
+fi
 
 # Create a default db called 'gis' or $POSTGRES_DBNAME that you can use to get up and running quickly
 # It will be owned by the docker db user


### PR DESCRIPTION
Env variable POSTGRES_TEMPLATE_EXTENSIONS added. If set to true, extensions will also be created in template1 database. This is useful for frameworks like Django where test databases are build every time by using the template.