### PR TITLE
Added file_env function to utilise secrets. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ You can also define any other configuration to add to `postgres.conf`, separated
 * -e EXTRA_CONF="log_destination = 'stderr'\nlogging_collector = on"
 
 
+## Docker secrets
+
+To avoid passing sensitive information in environment variables, `_FILE` can be appended to
+some of the variables to read from files present in the container. This is particularly useful
+in conjunction with Docker secrets, as passwords can be loaded from `/run/secrets/<secret_name>` e.g.:
+
+* -e POSTGRES_PASS_FILE=/run/secrets/<pg_pass_secret>
+
+For more information see [https://docs.docker.com/engine/swarm/secrets/](https://docs.docker.com/engine/swarm/secrets/).
+
+Currently, `POSTGRES_PASS`, `POSTGRES_USER` and `POSTGRES_DB` are supported.
+
 
 ## Convenience docker-compose.yml
 

--- a/env-data.sh
+++ b/env-data.sh
@@ -17,6 +17,34 @@ PGSTAT_TMP="/var/run/postgresql/"
 PG_PID="/var/run/postgresql/12-main.pid"
 
 
+# Read data from secrets into env variables.
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+function file_env {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'POSTGRES_PASS'
+file_env 'POSTGRES_USER'
+file_env 'POSTGRES_DBNAME'
+
 # Make sure we have a user set up
 if [ -z "${POSTGRES_USER}" ]; then
 	POSTGRES_USER=docker


### PR DESCRIPTION
I've added the file_env function from the docker-library images to enable using secrets rather than environment variables (https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images) for some of the main environment options (POSTGRESS_USER, POSTGRES_PASS, POSTGRES_DBNAME). I tried to keep the formatting relatively consistent, and placed it in the env-data.sh script as that seemed most appropriate.