### PR TITLE
Reorder Dockerfile to better utilize layer caching and minimize final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,3 @@ RUN set -eux \
 VOLUME /var/lib/postgresql
 
 ENTRYPOINT /docker-entrypoint.sh
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,19 @@ MAINTAINER Tim Sutton<tim@kartoza.com>
 
 # Reset ARG for version
 ARG IMAGE_VERSION
-RUN  export DEBIAN_FRONTEND=noninteractive
-ENV  DEBIAN_FRONTEND noninteractive
-RUN  dpkg-divert --local --rename --add /sbin/initctl
 
-RUN apt-get -y update; apt-get -y install locales gnupg2 wget ca-certificates rpl pwgen software-properties-common gdal-bin
+RUN set -eux \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+        locales gnupg2 wget ca-certificates rpl pwgen software-properties-common gdal-bin \
+    && sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt/ ${IMAGE_VERSION}-pgdg main\" > /etc/apt/sources.list.d/pgdg.list" \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add - \
+    && apt-get -y --purge autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkg-divert --local --rename --add /sbin/initctl
 
-RUN sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main\" > /etc/apt/sources.list.d/pgdg.list"
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add -
 # Generating locales takes a long time. Utilize caching by runnig it by itself
 # early in the build process.
 COPY locale.gen /etc/locale.gen
@@ -30,8 +35,16 @@ RUN update-locale ${LANG}
 # We add postgis as well to prevent build errors (that we dont see on local builds)
 # on docker hub e.g.
 # The following packages have unmet dependencies:
-RUN apt-get update; apt-get install -y postgresql-client-12 postgresql-common postgresql-12 postgresql-12-postgis-3 \
- netcat postgresql-12-ogr-fdw postgresql-12-postgis-3-scripts postgresql-12-cron postgresql-plpython3-12
+RUN set -eux \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install postgresql-client-12 \
+        postgresql-common postgresql-12 postgresql-12-postgis-3 \
+        netcat postgresql-12-ogr-fdw postgresql-12-postgis-3-scripts \
+        postgresql-12-cron postgresql-plpython3-12 \
+    && apt-get -y --purge autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Open port 5432 so linked containers can see them
 EXPOSE 5432

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
 ARG IMAGE_VERSION=buster
-FROM debian:$IMAGE_VERSION
+ARG IMAGE_VARIANT=-slim
+FROM debian:$IMAGE_VERSION$IMAGE_VARIANT
 MAINTAINER Tim Sutton<tim@kartoza.com>
 
 # Reset ARG for version

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,23 +49,25 @@ RUN set -eux \
 # Open port 5432 so linked containers can see them
 EXPOSE 5432
 
+# Copy scripts
+COPY docker-entrypoint.sh \
+     env-data.sh \
+     setup.sh \
+     setup-conf.sh \
+     setup-database.sh \
+     setup-pg_hba.sh \
+     setup-replication.sh \
+     setup-ssl.sh \
+     setup-user.sh \
+     /
+
 # Run any additional tasks here that are too tedious to put in
 # this dockerfile directly.
-ADD env-data.sh /env-data.sh
-ADD setup.sh /setup.sh
-RUN chmod +x /setup.sh
-RUN /setup.sh
+RUN set -eux \
+    && chmod +x /setup.sh \
+    && /setup.sh \
+    && chmod +x /docker-entrypoint.sh
 
-# We will run any commands in this when the container starts
-
-ADD docker-entrypoint.sh /docker-entrypoint.sh
-ADD setup-conf.sh /
-ADD setup-database.sh /
-ADD setup-pg_hba.sh /
-ADD setup-replication.sh /
-ADD setup-ssl.sh /
-ADD setup-user.sh /
-RUN chmod +x /docker-entrypoint.sh
 
 ENTRYPOINT /docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get -y --no-install-recommends install \
-        locales gnupg2 wget ca-certificates rpl pwgen software-properties-common gdal-bin \
+        locales gnupg2 wget ca-certificates rpl pwgen software-properties-common gdal-bin iputils-ping \
     && sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt/ ${IMAGE_VERSION}-pgdg main\" > /etc/apt/sources.list.d/pgdg.list" \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add - \
     && apt-get -y --purge autoremove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN set -eux \
     && /setup.sh \
     && chmod +x /docker-entrypoint.sh
 
+VOLUME /var/lib/postgresql
 
 ENTRYPOINT /docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,6 @@ ADD setup-replication.sh /
 ADD setup-ssl.sh /
 ADD setup-user.sh /
 RUN chmod +x /docker-entrypoint.sh
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && dpkg --remove --force-depends unzip
 
 ENTRYPOINT /docker-entrypoint.sh
 


### PR DESCRIPTION
Mostly move things around and group operations while trying to maintain readability.

Notice that the postgresql repo definition uses `IMAGE_VERSION` instead of `lsb_release` as the codename output from `lsb_release -c -s` for the current debian:buster base image is _sid_ and not _buster_. Probably a bug in Debian stable but better to be more explicit about which repo to use.