### PR TITLE
Fix env variable PG_WAL_KEEP_SEGMENTS is ignored (#222)

### DIFF
--- a/setup-conf.sh
+++ b/setup-conf.sh
@@ -27,7 +27,6 @@ wal_keep_segments = ${PG_WAL_KEEP_SEGMENTS}
 superuser_reserved_connections= 10
 min_wal_size = ${MIN_WAL_SIZE}
 max_wal_size = ${WAL_SIZE}
-wal_keep_segments= 64
 hot_standby = on
 listen_addresses = '${IP_LIST}'
 shared_buffers = 500MB


### PR DESCRIPTION
deleted one line, which hardcoded the value for wal_keep_segments