### PR TITLE
Fix building using a base image to speed up tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
 ARG DISTRO=debian
 ARG IMAGE_VERSION=buster
-ARG IMAGE_VARIANT=-slim
+ARG IMAGE_VARIANT=slim
 FROM kartoza/postgis:$DISTRO-$IMAGE_VERSION-$IMAGE_VARIANT
 MAINTAINER Tim Sutton<tim@kartoza.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG DISTRO=debian
 ARG IMAGE_VERSION=buster
 ARG IMAGE_VARIANT=-slim
-FROM $DISTRO:$IMAGE_VERSION$IMAGE_VARIANT
+FROM kartoza/postgis:$DISTRO-$IMAGE_VERSION-$IMAGE_VARIANT
 MAINTAINER Tim Sutton<tim@kartoza.com>
 
 # Reset ARG for version
@@ -11,8 +11,6 @@ ARG IMAGE_VERSION
 RUN set -eux \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get -y --no-install-recommends install \
-        locales gnupg2 wget ca-certificates rpl pwgen software-properties-common gdal-bin iputils-ping \
     && sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt/ ${IMAGE_VERSION}-pgdg main\" > /etc/apt/sources.list.d/pgdg.list" \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add - \
     && apt-get -y --purge autoremove \
@@ -20,16 +18,6 @@ RUN set -eux \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg-divert --local --rename --add /sbin/initctl
 
-# Generating locales takes a long time. Utilize caching by runnig it by itself
-# early in the build process.
-COPY scripts/locale.gen /etc/locale.gen
-RUN set -eux \
-    && /usr/sbin/locale-gen
-
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
-RUN update-locale ${LANG}
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
@@ -42,10 +30,9 @@ RUN set -eux \
     && apt-get -y --no-install-recommends install postgresql-client-12 \
         postgresql-common postgresql-12 postgresql-12-postgis-3 \
         netcat postgresql-12-ogr-fdw postgresql-12-postgis-3-scripts \
-        postgresql-12-cron postgresql-plpython3-12 postgresql-12-pgrouting
+        postgresql-12-cron postgresql-plpython3-12 postgresql-12-pgrouting postgresql-server-dev-12
 
 # Compile pointcloud extension
-RUN apt-get -y update; apt-get -y install build-essential autoconf postgresql-server-dev-12 libxml2-dev zlib1g-dev
 
 RUN wget -O- https://github.com/pgpointcloud/pointcloud/archive/master.tar.gz | tar xz && \
 cd pointcloud-master && \

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ and `IMAGE_VARIANT` (=slim) which can be used to control the base image used
 (but it still needs to be Debian based and have PostgreSQL official apt repo).
 
 For example making Ubuntu 20.04 based build (for better arm64 support)
+First build the base image using the branch `postgres-base` following instructions from [Kartoza base image builds](https://github.com/kartoza/docker-postgis/tree/postgres-base#alternative-base-distributions-builds)
+
+And then build the `PostGIS Image` using
+
 ```
 docker build --build-arg DISTRO=ubuntu --build-arg IMAGE_VERSION=focal --build-arg IMAGE_VARIANT="" -t kartoza/postgis .
 ```


### PR DESCRIPTION
* Fix base builds using base image

cc @lucernae I have created a branch https://github.com/kartoza/docker-postgis/tree/postgres-base which I used to build 
the base image `kartoza/postgis:debian-buster-slim`

