### PR TITLE
Fix passwords to use all characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In addition to that, we have another parameter: `RECREATE_DATADIR` that can be u
 If this parameter is specified as `TRUE` it will act as explicit consent to delete `DATADIR` and create
 new db cluster.
 
-* `RECREATE_DATADIR`: Force database reinitializations in the location `DATADIR`
+* `RECREATE_DATADIR`: Force database reinitialization in the location `DATADIR`
 
 If you used `RECREATE_DATADIR` and successfully created new cluster. Remember
 that you should remove this parameter afterwards. Because, if it was not omitted,
@@ -181,6 +181,9 @@ user name, password and/or default database name(or multiple databases comma sep
 
 * `-e POSTGRES_USER=<PGUSER>`
 * `-e POSTGRES_PASS=<PGPASSWORD>`
+**NB** You should use a strong passwords. If you are using docker-compose make sure
+docker can interpolate the password. Example using a password with a `$` you will 
+need to escape it ie `$$`
 * `-e POSTGRES_DBNAME=<PGDBNAME>`
 * `-e POSTGRES_MULTIPLE_EXTENSIONS=postgis,hstore,postgis_topology,postgis_raster,pgrouting`
 

--- a/scripts/setup-user.sh
+++ b/scripts/setup-user.sh
@@ -14,24 +14,44 @@ source /scripts/env-data.sh
 
 # Only create credentials if this is a master database
 # Slave database will just mirror from master users
-echo "Setup postgres User:Password"
-echo "postgresql user: $POSTGRES_USER" > /tmp/PGPASSWORD.txt
-echo "postgresql password: $POSTGRES_PASS" >> /tmp/PGPASSWORD.txt
 
-# Check user already exists
-echo "Creating superuser $POSTGRES_USER"
+echo "$POSTGRES_PASS" >> /tmp/PGPASSWORD.txt
+# Check super user already exists
 RESULT=`su - postgres -c "psql postgres -t -c \"SELECT 1 FROM pg_roles WHERE rolname = '$POSTGRES_USER'\""`
 COMMAND="ALTER"
 if [ -z "$RESULT" ]; then
 	COMMAND="CREATE"
 fi
-su - postgres -c "psql postgres -c \"$COMMAND USER $POSTGRES_USER WITH SUPERUSER ENCRYPTED PASSWORD '$POSTGRES_PASS';\""
 
-echo "Creating replication user $REPLICATION_USER"
+echo "Creating superuser user $POSTGRES_USER using $PASSWORD_AUTHENTICATION authentication "
+if [ PASSWORD_AUTHENTICATION="md5" ]; then
+	PG_PASS=$(U=$POSTGRES_USER; P=$(cat /tmp/PGPASSWORD.txt); echo -n md5; echo -n $P$U | md5sum | cut -d' ' -f1)
+	su - postgres -c "psql postgres -c \"$COMMAND USER $POSTGRES_USER WITH SUPERUSER  PASSWORD '$PG_PASS';\""
+elif [ PASSWORD_AUTHENTICATION="scram-sha-256" ]; then
+  PG_PASS=$(U=$POSTGRES_USER; P=$(cat /tmp/PGPASSWORD.txt); echo -n sha256; echo -n $P$U | sha256sum | cut -d' ' -f1)
+  su - postgres -c "psql postgres -c \"$COMMAND USER $POSTGRES_USER WITH SUPERUSER PASSWORD  '$PG_PASS';\""
+fi
+
+echo "$REPLICATION_PASS" >> /tmp/REPLICATION_PASS.txt
+
+# Check replication user already exists
 RESULT_REPLICATION=`su - postgres -c "psql postgres -t -c \"SELECT 1 FROM pg_roles WHERE rolname = '$REPLICATION_USER'\""`
 COMMANDS="ALTER"
 if [ -z "$RESULT_REPLICATION" ]; then
   COMMANDS="CREATE"
 fi
-su - postgres -c "psql postgres -c \"$COMMANDS USER $REPLICATION_USER WITH REPLICATION ENCRYPTED PASSWORD '$REPLICATION_PASS';\""
 
+if [ -z "$RESULT" ]; then
+	COMMAND="CREATE"
+fi
+
+echo "Creating replication user $REPLICATION_USER using $PASSWORD_AUTHENTICATION authentication "
+if [ PASSWORD_AUTHENTICATION="md5" ]; then
+	REP_PASS=$(U=$REPLICATION_USER; P=$(cat /tmp/REPLICATION_PASS.txt); echo -n md5; echo -n $P$U | md5sum | cut -d' ' -f1)
+	su - postgres -c "psql postgres -c \"$COMMANDS USER $REPLICATION_USER WITH REPLICATION  PASSWORD '$REP_PASS';\""
+elif [ PASSWORD_AUTHENTICATION="scram-sha-256" ]; then
+  REP_PASS=$(U=$REPLICATION_USER; P=$(cat /tmp/REPLICATION_PASS.txt); echo -n sha256; echo -n $P$U | sha256sum | cut -d' ' -f1)
+  su - postgres -c "psql postgres -c \"$COMMANDS USER $REPLICATION_USER WITH REPLICATION  PASSWORD '$REP_PASS';\""
+fi
+
+rm /tmp/PGPASSWORD.txt /tmp/REPLICATION_PASS.txt


### PR DESCRIPTION
Fixes #267 

* Initially tried to use sed to do escape all special characters but realised that they were passed to postgres as is there invalidating the user credentials.

@lucernae Can you test