### PR TITLE
Add kubctl yaml deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,7 @@ RUN set -eux \
 
 RUN apt-get -y update; apt-get -y install build-essential autoconf  libxml2-dev zlib1g-dev netcat gdal-bin
 
-# Temporary - PostgreSQL requires this which is not available in bullseye
-RUN	if [ ${IMAGE_VERSION} = "bullseye"  ]; then \
-		wget --progress=bar:force:noscroll -c --no-check-certificate http://ftp.br.debian.org/debian/pool/main/g/gdal/libgdal27_3.1.4+dfsg-1+b1_amd64.deb && \
-		dpkg -i libgdal27_3.1.4+dfsg-1+b1_amd64.deb && \
-		rm libgdal27_3.1.4+dfsg-1+b1_amd64.deb; \
-	fi
+
 
 # Generating locales takes a long time. Utilize caching by runnig it by itself
 # early in the build process.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,18 +17,17 @@ RUN set -eux \
     && apt-get update \
     && apt-get -y --no-install-recommends install \
         locales gnupg2 wget ca-certificates rpl pwgen software-properties-common  iputils-ping \
-        apt-transport-https curl \
+        apt-transport-https curl gettext \
     && dpkg-divert --local --rename --add /sbin/initctl
-
-
 
 RUN apt-get -y update; apt-get -y install build-essential autoconf  libxml2-dev zlib1g-dev netcat gdal-bin
 
-
-
 # Temporary - PostgreSQL requires this which is not available in bullseye
-ADD base_build/gdal_install.sh /gdal_install.sh
-RUN chmod 0755 /gdal_install.sh;/bin/bash /gdal_install.sh
+RUN	if [ ${IMAGE_VERSION} = "bullseye"  ]; then \
+		wget --progress=bar:force:noscroll -c --no-check-certificate http://ftp.br.debian.org/debian/pool/main/g/gdal/libgdal27_3.1.4+dfsg-1+b1_amd64.deb && \
+		dpkg -i libgdal27_3.1.4+dfsg-1+b1_amd64.deb && \
+		rm libgdal27_3.1.4+dfsg-1+b1_amd64.deb; \
+	fi
 
 # Generating locales takes a long time. Utilize caching by runnig it by itself
 # early in the build process.

--- a/README.md
+++ b/README.md
@@ -247,9 +247,15 @@ all connections.
 
 #### Additional configuration
 
-You can also define any other configuration to add to `postgres.conf`, separated by '\n' e.g.:
+You can also define any other configuration to add to `extra.conf`, separated by '\n' e.g.:
 
 * `-e EXTRA_CONF="log_destination = 'stderr'\nlogging_collector = on"`
+
+You can alternatively mount an extra  config file into the setting's folder i.e
+
+```
+docker run --name "postgis" -v /data/extra.conf:/settings/extra.conf -p 25432:5432 -d -t kartoza/postgis
+```
 
 If you want to reinitialize the data directory from scratch, you need to do:
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ the extension is installed with the image.
 
  ` Specifies whether extensions will also be installed in template1 database.`
 
+### Schema Initialisation
+* `-e SCHEMA_NAME=<PGSCHEMA>`
+You can pass a comma separated value of schema names which will be created when the
+  database initialises. The default behaviour is to create the schema in the first
+  database specified in the environment variable `POSTGRES_DBNAME`. If you need to
+  create matching schemas in all the databases that will be created you use
+  the environment variable `ALL_DATABASES=TRUE`
+  
 #### Configures archive mode
 
 This image uses the initial PostgreSQL values which disables the archiving option by default.

--- a/base_build/gdal_install.sh
+++ b/base_build/gdal_install.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if [[ ${IMAGE_VERSION} =~ [Bb][Uu][Ll][Ll][Ss][Ee][Yy][Ee] ]]; then
-  wget --progress=bar:force:noscroll -c --no-check-certificate http://ftp.br.debian.org/debian/pool/main/g/gdal/libgdal27_3.1.4+dfsg-1+b1_amd64.deb
-  dpkg -i libgdal27_3.1.4+dfsg-1+b1_amd64.deb
-fi
-

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,5 +1,5 @@
 # Used solely for docker-compose build
-version: '3'
+version: '3.9'
 services:
   postgis-base:
     image: kartoza/postgis:base-${DISTRO}-${IMAGE_VERSION}-${IMAGE_VARIANT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 services:
 
   db:
-    image: kartoza/postgis:13.1
+    image: kartoza/postgis:13-3.1
     volumes:
       - postgis-data:/var/lib/postgresql
       - dbbackups:/backups

--- a/kubernetes/db-deployment.yaml
+++ b/kubernetes/db-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db-deploy
+  labels:
+    name: db-pod
+    app: postgis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: db-pod
+      app: postgis
+  template:
+    metadata:
+      name: db-pod
+      labels:
+        name: db-pod
+        app: postgis
+    spec:
+      containers:
+        - name: db
+          image: kartoza/postgis:13.0
+          env:
+            - name: ALLOW_IP_RANGE
+              value: "0.0.0.0/0"
+            - name: POSTGRES_DB
+              value: "gis"
+            - name: POSTGRES_PASS
+              value: "docker"
+            - name: POSTGRES_USER
+              value: "docker"
+            - name: POSTGRES_PORT
+              value: "5432"
+          ports:
+            - containerPort: 5432
+
+

--- a/kubernetes/db-service.yaml
+++ b/kubernetes/db-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  labels:
+    name: db-service
+    app: postgis
+spec:
+  type: NodePort
+  ports:
+    - port: 5432
+      targetPort: 5432
+      nodePort: 30009
+
+  selector:
+    name: db-pod
+    app: postgis
+

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -89,6 +89,10 @@ if [ -z "${RECREATE_DATADIR}" ]; then
 else
   RECREATE_DATADIR=$(boolean ${RECREATE_DATADIR})
 fi
+
+if [ -z "${ALL_DATABASES}" ]; then
+  ALL_DATABASES=FALSE
+fi
 # SSL mode
 if [ -z "${PGSSLMODE}" ]; then
 	PGSSLMODE=require

--- a/scripts/setup-conf.sh
+++ b/scripts/setup-conf.sh
@@ -15,10 +15,7 @@ cat $CONF.template > $CONF
 sed -i '/data_directory/d' $CONF
 
 # Create a config to optimise postgis
-if [[  -f ${ROOT_CONF}/postgis.conf ]];then
-  rm $CONF/postgis.conf
-fi
-cat >> ${ROOT_CONF}/postgis.conf <<EOF
+cat > ${ROOT_CONF}/postgis.conf <<EOF
 data_directory = '${DATADIR}'
 port = 5432
 superuser_reserved_connections= 10
@@ -42,10 +39,8 @@ echo "include 'postgis.conf'" >> $CONF
 
 # Create a config for logical replication
 if [[  "${REPLICATION}" =~ [Tt][Rr][Uu][Ee] && "$WAL_LEVEL" == 'logical' ]]; then
-  if [[  -f ${ROOT_CONF}/logical_replication.conf ]];then
-    rm $CONF/logical_replication.conf
-  fi
-cat >> ${ROOT_CONF}/logical_replication.conf <<EOF
+
+cat > ${ROOT_CONF}/logical_replication.conf <<EOF
 wal_level = ${WAL_LEVEL}
 max_wal_senders = ${PG_MAX_WAL_SENDERS}
 wal_keep_size = ${PG_WAL_KEEP_SIZE}
@@ -59,10 +54,8 @@ fi
 
 # Create a config for streaming replication
 if [[ "${REPLICATION}" =~ [Tt][Rr][Uu][Ee] &&  "$WAL_LEVEL" == 'replica' ]]; then
-  if [[  -f ${ROOT_CONF}/streaming_replication.conf ]];then
-    rm $CONF/streaming_replication.conf
-  fi
-cat >> ${ROOT_CONF}/streaming_replication.conf <<EOF
+
+cat > ${ROOT_CONF}/streaming_replication.conf <<EOF
 wal_level = ${WAL_LEVEL}
 archive_mode = ${ARCHIVE_MODE}
 archive_command = '${ARCHIVE_COMMAND}'
@@ -82,13 +75,20 @@ EOF
 echo "include 'streaming_replication.conf'" >> $CONF
 fi
 
-if [[  -f ${ROOT_CONF}/extra.conf ]];then
-    rm $CONF/extra.conf
-fi
+if [[ ! -f ${ROOT_CONF}/extra.conf ]]; then
+    echo "${ROOT_CONF}/extra.conf doesn't exists"
+    # If it doesn't exists, copy from /settings directory if exists
+    if [[ -f /settings/extra.conf ]]; then
+      cp -f /settings/extra.conf ${ROOT_CONF}/extra.conf
+      echo "include 'extra.conf'" >> $CONF
+    else
+      # default value
+      if [[  ! -z $EXTRA_CONF ]]; then
+          echo -e $EXTRA_CONF >> ${ROOT_CONF}/extra.conf
+          echo "include 'extra.conf'" >> $CONF
+      fi
+    fi
 
-if [[  ! -z $EXTRA_CONF ]]; then
-  echo -e $EXTRA_CONF >> ${ROOT_CONF}/extra.conf
-  echo "include 'extra.conf'" >> $CONF
 fi
 
 # Optimise PostgreSQL shared memory for PostGIS

--- a/scripts/setup-conf.sh
+++ b/scripts/setup-conf.sh
@@ -76,7 +76,6 @@ echo "include 'streaming_replication.conf'" >> $CONF
 fi
 
 if [[ ! -f ${ROOT_CONF}/extra.conf ]]; then
-    echo "${ROOT_CONF}/extra.conf doesn't exists"
     # If it doesn't exists, copy from /settings directory if exists
     if [[ -f /settings/extra.conf ]]; then
       cp -f /settings/extra.conf ${ROOT_CONF}/extra.conf

--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -85,10 +85,10 @@ done
 for db in $(echo ${POSTGRES_DBNAME} | tr ',' ' '); do
     for schemas in $(echo ${SCHEMA_NAME} | tr ',' ' '); do
       SCHEMA_RESULT=`PGPASSWORD=${POSTGRES_PASS} psql -t ${db} -U ${POSTGRES_USER} -p 5432 -h localhost -c "select count(1) from information_schema.schemata where schema_name = '${schemas}' and catalog_name = '${db}';"`
-     if [[ ${SCHEMA_RESULT} -eq 0 || "${ALL_DATABASES}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
+     if [[ ${SCHEMA_RESULT} -eq 0 ]] && [[ "${ALL_DATABASES}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
           echo "Creating schema ${schemas} in database ${SINGLE_DB}"
           PGPASSWORD=${POSTGRES_PASS} psql ${SINGLE_DB} -U ${POSTGRES_USER} -p 5432 -h localhost -c " CREATE SCHEMA IF NOT EXISTS ${schemas};"
-      elif [[ ${SCHEMA_RESULT} -eq 0 || "${ALL_DATABASES}" =~ [Tt][Rr][Uu][Ee] ]]; then
+      elif [[ ${SCHEMA_RESULT} -eq 0 ]] && [[ "${ALL_DATABASES}" =~ [Tt][Rr][Uu][Ee] ]]; then
           echo "Creating schema ${schemas} in database ${db}"
           PGPASSWORD=${POSTGRES_PASS} psql ${db} -U ${POSTGRES_USER} -p 5432 -h localhost -c " CREATE SCHEMA IF NOT EXISTS ${schemas};"
       fi

--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -53,8 +53,10 @@ fi
 # It will be owned by the docker db user
 # Since we now pass a comma separated list in database creation we need to search for all databases as a test
 
+
 for db in $(echo ${POSTGRES_DBNAME} | tr ',' ' '); do
         RESULT=`su - postgres -c "psql -t -c \"SELECT count(1) from pg_database where datname='${db}';\""`
+
         if [[  ${RESULT} -eq 0 ]]; then
             echo "Create db ${db}"
             su - postgres -c "createdb -O ${POSTGRES_USER} ${db}"
@@ -78,6 +80,21 @@ for db in $(echo ${POSTGRES_DBNAME} | tr ',' ' '); do
          echo "${db} db already exists"
         fi
 done
+
+# Create schemas in the DB
+for db in $(echo ${POSTGRES_DBNAME} | tr ',' ' '); do
+    for schemas in $(echo ${SCHEMA_NAME} | tr ',' ' '); do
+      SCHEMA_RESULT=`PGPASSWORD=${POSTGRES_PASS} psql -t ${db} -U ${POSTGRES_USER} -p 5432 -h localhost -c "select count(1) from information_schema.schemata where schema_name = '${schemas}' and catalog_name = '${db}';"`
+     if [[ ${SCHEMA_RESULT} -eq 0 || "${ALL_DATABASES}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
+          echo "Creating schema ${schemas} in database ${SINGLE_DB}"
+          PGPASSWORD=${POSTGRES_PASS} psql ${SINGLE_DB} -U ${POSTGRES_USER} -p 5432 -h localhost -c " CREATE SCHEMA IF NOT EXISTS ${schemas};"
+      elif [[ ${SCHEMA_RESULT} -eq 0 || "${ALL_DATABASES}" =~ [Tt][Rr][Uu][Ee] ]]; then
+          echo "Creating schema ${schemas} in database ${db}"
+          PGPASSWORD=${POSTGRES_PASS} psql ${db} -U ${POSTGRES_USER} -p 5432 -h localhost -c " CREATE SCHEMA IF NOT EXISTS ${schemas};"
+      fi
+    done
+done
+
 
 CRON_LOCKFILE="${ROOT_CONF}/.cron_ext.lock"
 if [ ! -f "${CRON_LOCKFILE}" ]; then

--- a/scripts/setup-pg_hba.sh
+++ b/scripts/setup-pg_hba.sh
@@ -12,6 +12,11 @@ fi
 # Reconfigure pg_hba if environment settings changed
 cat ${ROOT_CONF}/pg_hba.conf.template > ${ROOT_CONF}/pg_hba.conf
 
+# Restrict subnet to docker private network
+echo "host    all             all             172.0.0.0/8              ${PASSWORD_AUTHENTICATION}" >> $ROOT_CONF/pg_hba.conf
+# And allow access from DockerToolbox / Boot to docker on OSX
+echo "host    all             all             192.168.0.0/16               ${PASSWORD_AUTHENTICATION}" >> $ROOT_CONF/pg_hba.conf
+
 # Custom IP range via docker run -e (https://docs.docker.com/engine/reference/run/#env-environment-variables)
 # Usage is: docker run [...] -e ALLOW_IP_RANGE='192.168.0.0/16'
 if [[ "$ALLOW_IP_RANGE" ]]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,12 +5,6 @@ chmod 600 /etc/ssl/private/ssl-cert-snakeoil.key
 # These tasks are run as root
 source /scripts/env-data.sh
 
-
-# Restrict subnet to docker private network
-echo "host    all             all             172.0.0.0/8              ${PASSWORD_AUTHENTICATION}" >> $ROOT_CONF/pg_hba.conf
-# And allow access from DockerToolbox / Boot to docker on OSX
-echo "host    all             all             192.168.0.0/16               ${PASSWORD_AUTHENTICATION}" >> $ROOT_CONF/pg_hba.conf
-
 # Create backup template for conf
 cat $CONF > $CONF.template
 cat $ROOT_CONF/pg_hba.conf > $ROOT_CONF/pg_hba.conf.template


### PR DESCRIPTION
* Add YAML for kubectl deployments.
* Add new env variable `SCHEMA_NAME` to create comma separated lists of schemas, `ALL_DATABASES` - to control if schema creation should be in a single DB or all listed DB's
* Add option to mount extra conf as a volume
* Fix issue with pg_hba hardcoded values during a build
