### PR TITLE
Fix error on enabling uuid-ossp extension

### DIFF
--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -44,8 +44,8 @@ source /scripts/setup-user.sh
 # enable extensions in template1 if env variable set to true
 if [[ "$(boolean ${POSTGRES_TEMPLATE_EXTENSIONS})" == TRUE ]] ; then
     for ext in $(echo ${POSTGRES_MULTIPLE_EXTENSIONS} | tr ',' ' '); do
-        echo "Enabling ${ext} in the database template1"
-        su - postgres -c "psql -c 'CREATE EXTENSION IF NOT EXISTS ${ext} cascade;' template1"
+        echo "Enabling \"${ext}\" in the database template1"
+        su - postgres -c "psql -c 'CREATE EXTENSION IF NOT EXISTS \"${ext}\" cascade;' template1"
     done
 fi
 
@@ -61,11 +61,11 @@ for db in $(echo ${POSTGRES_DBNAME} | tr ',' ' '); do
             echo "Create db ${db}"
             su - postgres -c "createdb -O ${POSTGRES_USER} ${db}"
             for ext in $(echo ${POSTGRES_MULTIPLE_EXTENSIONS} | tr ',' ' '); do
-                echo "Enabling ${ext} in the database ${db}"
+                echo "Enabling \"${ext}\" in the database ${db}"
                 if [[ ${ext} = 'pg_cron' ]]; then
                   echo " pg_cron doesn't need to be installed"
                 else
-                  su - postgres -c "psql -c 'CREATE EXTENSION IF NOT EXISTS ${ext} cascade;' $db"
+                  su - postgres -c "psql -c 'CREATE EXTENSION IF NOT EXISTS \"${ext}\" cascade;' $db"
                 fi
             done
             echo "Loading legacy sql"


### PR DESCRIPTION
Hello,
enabling uuid-ossp postgres extension will cause the container to be failed.
to reproduce the error run the code below:

`docker run -it --env POSTGRES_MULTIPLE_EXTENSIONS="uuid-ossp" postgis:11.0-2.5`


> ...
> Create db gis
> Enabling uuid-ossp in the database gis
> 2021-05-10 10:05:26.954 UTC [169] postgres@gis ERROR:  syntax error at or near "-" at character 36
> 2021-05-10 10:05:26.954 UTC [169] postgres@gis STATEMENT:  CREATE EXTENSION IF NOT EXISTS uuid-ossp cascade;
> ERROR:  syntax error at or near "-"
> LINE 1: CREATE EXTENSION IF NOT EXISTS uuid-ossp cascade;