### PR TITLE
Fix SSL configs for forcing client connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,61 @@ See [the postgres documentation about SSL](https://www.postgresql.org/docs/11/li
 
 See [the postgres documentation about encoding](https://www.postgresql.org/docs/11/multibyte.html) for more information.
 
+### SSL Client connection using default certificates
 To force SSL connection between clients you need to use the environment 
 variable `FORCE_SSL=TRUE`
+
+If you are using the default certificates provided by the image when connecting
+to the database you will need to set `SSL Mode` to any value besides
+`verify-full` or `verify-ca`
+
+### SSL Client connection using user defined certificates
+To force SSL connection between clients you need to use the environment 
+variable `FORCE_SSL=TRUE`
+
+If you are using your own certificates when connecting to the database you will need to set
+`SSL Mode` to force the connection to use SSL.
+
+You also need to define the following environment variables when setting up the database connection.
+
+SSL_CERT_FILE:
+
+SSL_KEY_FILE: 
+
+SSL_CA_FILE:
+
+On the host machine where you need to connect to the database you also 
+need to copy the `SSL_CA_FILE` file to the location `/home/$user/.postgresql/root.crt`
+or define an environment variable pointing to location of the `SSL_CA_FILE`
+example: `PGSSLROOTCERT=/etc/letsencrypt/root.crt`
+
+#### SSL connection inside the docker container using openssl certificates
+
+
+Generate the certificates inside the container
+```
+LETSENCRYPT_CERT_DIR=/etc/letsencrypt
+mkdir $LETSENCRYPT_CERT_DIR
+openssl req -x509 -newkey rsa:4096 -keyout ${LETSENCRYPT_CERT_DIR}/privkey.pem -out \
+      ${LETSENCRYPT_CERT_DIR}/fullchain.pem -days 3650 -nodes -sha256 -subj '/CN=localhost'
+
+cp $LETSENCRYPT_CERT_DIR/fullchain.pem $LETSENCRYPT_CERT_DIR/root.crt
+chmod -R 0700 ${LETSENCRYPT_CERT_DIR}
+chown -R postgres ${LETSENCRYPT_CERT_DIR}
+```
+
+Set up your ssl config to point to the new location
+```
+ssl = true
+ssl_cert_file = '/etc/letsencrypt/fullchain.pem'
+ssl_key_file = '/etc/letsencrypt/privkey.pem'
+ssl_ca_file = '/etc/letsencrypt/root.crt' 
+```
+Then connect to the database using the psql command:
+```
+psql "dbname=gis port=5432 user=docker host=localhost sslmode=verify-full  sslcert=/etc/letsencrypt/fullchain.pem sslkey=/etc/letsencrypt/privkey.pem sslrootcert=/etc/letsencrypt/root.crt"
+
+```
 
 ## Postgres Replication Setup
 

--- a/scripts/setup-pg_hba.sh
+++ b/scripts/setup-pg_hba.sh
@@ -12,35 +12,46 @@ fi
 # Reconfigure pg_hba if environment settings changed
 cat ${ROOT_CONF}/pg_hba.conf.template > ${ROOT_CONF}/pg_hba.conf
 
-if [[ "$FORCE_SSL" =~ [Tt][Rr][Uu][Ee] ]]; then
-  PG_CONF_HOST='hostssl'
-  CERT_AUTH='cert'
+
+if [[ "${FORCE_SSL}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
+  PG_CONF_HOST='host'
+  CERT_AUTH=${PASSWORD_AUTHENTICATION}
+  CLIENT_VERIFY=
 else
-   PG_CONF_HOST='host'
-   CERT_AUTH=${PASSWORD_AUTHENTICATION}
+  # If user has their own cert we default to force auth using cert method
+  if  [[ "${SSL_KEY_FILE}" != '/etc/ssl/private/ssl-cert-snakeoil.key' ]]; then
+    PG_CONF_HOST='hostssl'
+    CERT_AUTH='cert'
+    CLIENT_VERIFY=
+  else
+    # Used when using the default ssl certs
+    PG_CONF_HOST='hostssl'
+    CERT_AUTH=${PASSWORD_AUTHENTICATION}
+    CLIENT_VERIFY='clientcert=0'
+  fi
 
 fi
 
-
-
 # Restrict subnet to docker private network
-echo "$PG_CONF_HOST   all             all             172.0.0.0/8              ${CERT_AUTH}" >> $ROOT_CONF/pg_hba.conf
+echo "$PG_CONF_HOST   all             all             172.0.0.0/8              ${CERT_AUTH}   $CLIENT_VERIFY" >> $ROOT_CONF/pg_hba.conf
 # And allow access from DockerToolbox / Boot to docker on OSX
-echo "$PG_CONF_HOST    all             all             192.168.0.0/16               ${CERT_AUTH}" >> $ROOT_CONF/pg_hba.conf
+echo "$PG_CONF_HOST    all             all             192.168.0.0/16               ${CERT_AUTH}    $CLIENT_VERIFY" >> $ROOT_CONF/pg_hba.conf
 
 # Custom IP range via docker run -e (https://docs.docker.com/engine/reference/run/#env-environment-variables)
 # Usage is: docker run [...] -e ALLOW_IP_RANGE='192.168.0.0/16'
 if [[ -n "$ALLOW_IP_RANGE" ]]
 then
 	echo "Add rule to pg_hba: $ALLOW_IP_RANGE"
- 	echo "$PG_CONF_HOST   all             all             $ALLOW_IP_RANGE              ${CERT_AUTH}" >> ${ROOT_CONF}/pg_hba.conf
+ 	echo "$PG_CONF_HOST   all             all             $ALLOW_IP_RANGE              ${CERT_AUTH}   $CLIENT_VERIFY" >> ${ROOT_CONF}/pg_hba.conf
 fi
 
 # check password first so we can output the warning before postgres
 # messes it up
+
 if [[ "$POSTGRES_PASS" ]]; then
 	pass="PASSWORD '$POSTGRES_PASS'"
 	authMethod=${CERT_AUTH}
+
 else
 	# The - option suppresses leading tabs but *not* spaces. :)
 	cat >&2 <<-'EOWARN'
@@ -65,7 +76,7 @@ if [[ -z "$REPLICATE_FROM" ]]; then
 	# if env not set, then assume this is master instance
 	# add rules to pg_hba.conf to allow replication from all
 	echo "Add rule to pg_hba: replication ${REPLICATION_USER} "
-	echo "$PG_CONF_HOST   replication            ${REPLICATION_USER}             ${ALLOW_IP_RANGE}          $authMethod" >> ${ROOT_CONF}/pg_hba.conf
+	echo "$PG_CONF_HOST   replication            ${REPLICATION_USER}             ${ALLOW_IP_RANGE}          $authMethod   $CLIENT_VERIFY" >> ${ROOT_CONF}/pg_hba.conf
 fi
 
 # Put lock file to make sure conf was not reinitialized


### PR DESCRIPTION
* Default behaviour does not force SSL connections
* Connect to SSL using the default snake oil certificates
* SSL verification when using user-defined certificates