### PR TITLE
Fix SSL configs for forcing client connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,61 @@ See [the postgres documentation about SSL](https://www.postgresql.org/docs/11/li
 
 See [the postgres documentation about encoding](https://www.postgresql.org/docs/11/multibyte.html) for more information.
 
+### SSL Client connection using default certificates
 To force SSL connection between clients you need to use the environment 
 variable `FORCE_SSL=TRUE`
+
+If you are using the default certificates provided by the image when connecting
+to the database you will need to set `SSL Mode` to any value besides
+`verify-full` or `verify-ca`
+
+### SSL Client connection using user defined certificates
+To force SSL connection between clients you need to use the environment 
+variable `FORCE_SSL=TRUE`
+
+If you are using your own certificates when connecting to the database you will need to set
+`SSL Mode` to force the connection to use SSL.
+
+You also need to define the following environment variables when setting up the database connection.
+
+SSL_CERT_FILE:
+
+SSL_KEY_FILE: 
+
+SSL_CA_FILE:
+
+On the host machine where you need to connect to the database you also 
+need to copy the `SSL_CA_FILE` file to the location `/home/$user/.postgresql/root.crt`
+or define an environment variable pointing to location of the `SSL_CA_FILE`
+example: `PGSSLROOTCERT=/etc/letsencrypt/root.crt`
+
+#### SSL connection inside the docker container using openssl certificates
+
+
+Generate the certificates inside the container
+```
+LETSENCRYPT_CERT_DIR=/etc/letsencrypt
+mkdir $LETSENCRYPT_CERT_DIR
+openssl req -x509 -newkey rsa:4096 -keyout ${LETSENCRYPT_CERT_DIR}/privkey.pem -out \
+      ${LETSENCRYPT_CERT_DIR}/fullchain.pem -days 3650 -nodes -sha256 -subj '/CN=localhost'
+
+cp $LETSENCRYPT_CERT_DIR/fullchain.pem $LETSENCRYPT_CERT_DIR/root.crt
+chmod -R 0700 ${LETSENCRYPT_CERT_DIR}
+chown -R postgres ${LETSENCRYPT_CERT_DIR}
+```
+
+Set up your ssl config to point to the new location
+```
+ssl = true
+ssl_cert_file = '/etc/letsencrypt/fullchain.pem'
+ssl_key_file = '/etc/letsencrypt/privkey.pem'
+ssl_ca_file = '/etc/letsencrypt/root.crt' 
+```
+Then connect to the database using the psql command:
+```
+psql "dbname=gis port=5432 user=docker host=localhost sslmode=verify-full  sslcert=/etc/letsencrypt/fullchain.pem sslkey=/etc/letsencrypt/privkey.pem sslrootcert=/etc/letsencrypt/root.crt"
+
+```
 
 ## Postgres Replication Setup
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ mounting an empty volume. Or use parameter `RECREATE_DATADIR` to forcefully
 delete the current cluster and create a new one. Make sure to remove parameter
 `RECREATE_DATADIR` after creating the cluster.
 
+See [the postgres documentation about encoding](https://www.postgresql.org/docs/11/multibyte.html) for more information.
 
 #### Basic configuration
 
@@ -342,7 +343,7 @@ When running scripts they will only be executed against the
 first database ie POSTGRES_DB=gis,data,sample
 The SQL script will be executed against the gis database. Additionally, a lock file is generated in `/docker-entrypoint-initdb.d`, which will prevent the scripts from getting executed after the first container startup. Provide `IGNORE_INIT_HOOK_LOCKFILE=true` to execute the scripts on _every_ container start.
 
-Currently you can pass `.sql` , `.sql.gz` and `.sh` files as mounted volumes.
+Currently, you can pass `.sql` , `.sql.gz` and `.sh` files as mounted volumes.
 
 ```
 
@@ -387,33 +388,19 @@ need to use the environment variable
 FORCE_SSL=TRUE
 ```
 
-The following is an example Dockerfile that sets up a container with custom ssl private key and certificate:
+The following example sets up a container with custom ssl private key and certificate:
+
 
 ```
-FROM kartoza/postgis:11.0-2.5
-
-ADD ssl_cert.pem /etc/ssl/certs/ssl_cert.pem
-ADD localhost_ssl_key.pem /etc/ssl/private/ssl_key.pem
-
-RUN chmod 400 /etc/ssl/private/ssl_key.pem
+docker run -p 25432:5432 -e FORCE_SSL=TRUE -e SSL_DIR="/etc/ssl_certificates" -e SSL_CERT_FILE='/etc/ssl_certificates/fullchain.pem' -e SSL_KEY_FILE='/etc/ssl_certificates/privkey.pem' -e SSL_CA_FILE='/etc/ssl_certificates/root.crt' -v /tmp/postgres/letsencrypt:/etc/ssl_certificates --name ssl -d kartoza/postgis:13-3.1
 ```
 
-The docker-compose.yml to initialize with this configuration:
-
-```
-services:
-  postgres:
-    build:
-      dockerfile: Dockerfile
-      context: ssl_secured_docker
-    environment:
-      - SSL_CERT_FILE=/etc/ssl/certs/ssl_cert.pem
-      - SSL_KEY_FILE=/etc/ssl/private/ssl_key.pem
-```
+The environment variable `SSL_DIR` allows a user to specify the location
+where custom SSL certificates will be located. The environment variable currently
+defaults to `SSL_DIR=/ssl_certificates`
 
 See [the postgres documentation about SSL](https://www.postgresql.org/docs/11/libpq-ssl.html#LIBQ-SSL-CERTIFICATES) for more information.
 
-See [the postgres documentation about encoding](https://www.postgresql.org/docs/11/multibyte.html) for more information.
 
 ### Forced SSL: forced using the shipped snakeoil certificates
 

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -89,6 +89,10 @@ if [ -z "${RECREATE_DATADIR}" ]; then
 else
   RECREATE_DATADIR=$(boolean ${RECREATE_DATADIR})
 fi
+if [ -z "${SSL_DIR}" ]; then
+  SSL_DIR="/ssl_certificates"
+fi
+
 # SSL mode
 if [ -z "${PGSSLMODE}" ]; then
 	PGSSLMODE=require

--- a/scripts/setup-pg_hba.sh
+++ b/scripts/setup-pg_hba.sh
@@ -12,35 +12,46 @@ fi
 # Reconfigure pg_hba if environment settings changed
 cat ${ROOT_CONF}/pg_hba.conf.template > ${ROOT_CONF}/pg_hba.conf
 
-if [[ "$FORCE_SSL" =~ [Tt][Rr][Uu][Ee] ]]; then
-  PG_CONF_HOST='hostssl'
-  CERT_AUTH='cert'
+
+if [[ "${FORCE_SSL}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
+  PG_CONF_HOST='host'
+  CERT_AUTH=${PASSWORD_AUTHENTICATION}
+  CLIENT_VERIFY=
 else
-   PG_CONF_HOST='host'
-   CERT_AUTH=${PASSWORD_AUTHENTICATION}
+  # If user has their own cert we default to force auth using cert method
+  if  [[ "${SSL_KEY_FILE}" != '/etc/ssl/private/ssl-cert-snakeoil.key' ]]; then
+    PG_CONF_HOST='hostssl'
+    CERT_AUTH='cert'
+    CLIENT_VERIFY=
+  else
+    # Used when using the default ssl certs
+    PG_CONF_HOST='hostssl'
+    CERT_AUTH=${PASSWORD_AUTHENTICATION}
+    CLIENT_VERIFY='clientcert=0'
+  fi
 
 fi
 
-
-
 # Restrict subnet to docker private network
-echo "$PG_CONF_HOST   all             all             172.0.0.0/8              ${CERT_AUTH}" >> $ROOT_CONF/pg_hba.conf
+echo "$PG_CONF_HOST   all             all             172.0.0.0/8              ${CERT_AUTH}   $CLIENT_VERIFY" >> $ROOT_CONF/pg_hba.conf
 # And allow access from DockerToolbox / Boot to docker on OSX
-echo "$PG_CONF_HOST    all             all             192.168.0.0/16               ${CERT_AUTH}" >> $ROOT_CONF/pg_hba.conf
+echo "$PG_CONF_HOST    all             all             192.168.0.0/16               ${CERT_AUTH}    $CLIENT_VERIFY" >> $ROOT_CONF/pg_hba.conf
 
 # Custom IP range via docker run -e (https://docs.docker.com/engine/reference/run/#env-environment-variables)
 # Usage is: docker run [...] -e ALLOW_IP_RANGE='192.168.0.0/16'
 if [[ -n "$ALLOW_IP_RANGE" ]]
 then
 	echo "Add rule to pg_hba: $ALLOW_IP_RANGE"
- 	echo "$PG_CONF_HOST   all             all             $ALLOW_IP_RANGE              ${CERT_AUTH}" >> ${ROOT_CONF}/pg_hba.conf
+ 	echo "$PG_CONF_HOST   all             all             $ALLOW_IP_RANGE              ${CERT_AUTH}   $CLIENT_VERIFY" >> ${ROOT_CONF}/pg_hba.conf
 fi
 
 # check password first so we can output the warning before postgres
 # messes it up
+
 if [[ "$POSTGRES_PASS" ]]; then
 	pass="PASSWORD '$POSTGRES_PASS'"
 	authMethod=${CERT_AUTH}
+
 else
 	# The - option suppresses leading tabs but *not* spaces. :)
 	cat >&2 <<-'EOWARN'
@@ -65,7 +76,7 @@ if [[ -z "$REPLICATE_FROM" ]]; then
 	# if env not set, then assume this is master instance
 	# add rules to pg_hba.conf to allow replication from all
 	echo "Add rule to pg_hba: replication ${REPLICATION_USER} "
-	echo "$PG_CONF_HOST   replication            ${REPLICATION_USER}             ${ALLOW_IP_RANGE}          $authMethod" >> ${ROOT_CONF}/pg_hba.conf
+	echo "$PG_CONF_HOST   replication            ${REPLICATION_USER}             ${ALLOW_IP_RANGE}          $authMethod   $CLIENT_VERIFY" >> ${ROOT_CONF}/pg_hba.conf
 fi
 
 # Put lock file to make sure conf was not reinitialized

--- a/scripts/setup-ssl.sh
+++ b/scripts/setup-ssl.sh
@@ -22,6 +22,10 @@ create_dir ${SSL_DIR}
 chmod -R 0700 ${SSL_DIR}
 chown -R postgres ${SSL_DIR}
 
+# Docker secrets for certificates
+file_env 'SSL_CERT_FILE'
+file_env 'SSL_KEY_FILE'
+file_env 'SSL_CA_FILE'
 
 # Needed under debian, wasn't needed under ubuntu
 mkdir -p ${PGSTAT_TMP}

--- a/scripts/setup-ssl.sh
+++ b/scripts/setup-ssl.sh
@@ -17,7 +17,13 @@ chown -R postgres /tmp/ssl-copy
 rm -r /etc/ssl
 mv /tmp/ssl-copy /etc/ssl
 
-# Needed under debian, wasnt needed under ubuntu
+# Setup Permission for SSL Directory
+create_dir ${SSL_DIR}
+chmod -R 0700 ${SSL_DIR}
+chown -R postgres ${SSL_DIR}
+
+
+# Needed under debian, wasn't needed under ubuntu
 mkdir -p ${PGSTAT_TMP}
 chmod 0777 ${PGSTAT_TMP}
 


### PR DESCRIPTION
- Default behaviour does not force SSL connections
- Connect to SSL using the default snake oil certificates
- SSL verification when using user-defined certificates
