### PR TITLE
mount lockfiles in persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,15 @@ You can alternatively mount an extra  config file into the setting's folder i.e
 docker run --name "postgis" -v /data/extra.conf:/settings/extra.conf -p 25432:5432 -d -t kartoza/postgis
 ```
 
+The setting folder storing the extra configuration is controlled by the env
+variable `EXTRA_CONF_DIR`
+
+Running the command can then be called:
+
+```
+docker run --name "postgis" -e EXTRA_CONF_DIR=/etc/conf_settings -v /data:/etc/conf_settings -p 25432:5432 -d -t kartoza/postgis
+```
+
 If you want to reinitialize the data directory from scratch, you need to do:
 
 1. Do backup, move data, etc. Any preparations before deleting your data directory.

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -81,6 +81,10 @@ fi
 if [ -z "${DATADIR}" ]; then
   DATADIR=${DEFAULT_DATADIR}
 fi
+
+if [ -z "${EXTRA_CONF_DIR}" ]; then
+  EXTRA_CONF_DIR=/settings
+fi
 # RECREATE_DATADIR flag default value
 # Always assume that we don't want to recreate datadir if not explicitly defined
 # For issue: https://github.com/kartoza/docker-postgis/issues/226
@@ -334,7 +338,7 @@ function restart_postgres {
 # Running extended script or sql if provided.
 # Useful for people who extends the image.
 function entry_point_script {
-  SETUP_LOCKFILE="/docker-entrypoint-initdb.d/.entry_point.lock"
+  SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.entry_point.lock"
   # If lockfile doesn't exists, proceed.
   if [[ ! -f "${SETUP_LOCKFILE}" ]] || [ "${IGNORE_INIT_HOOK_LOCKFILE}" == true ]; then
       if find "/docker-entrypoint-initdb.d" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then

--- a/scripts/setup-conf.sh
+++ b/scripts/setup-conf.sh
@@ -3,6 +3,7 @@
 source /scripts/env-data.sh
 
 create_dir ${EXTRA_CONF_DIR}
+create_dir ${CONF_LOCKFILE_DIR}
 
 SETUP_LOCKFILE="${CONF_LOCKFILE_DIR}/.postgresql.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then

--- a/scripts/setup-conf.sh
+++ b/scripts/setup-conf.sh
@@ -4,7 +4,7 @@ source /scripts/env-data.sh
 
 create_dir ${EXTRA_CONF_DIR}
 
-SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.postgresql.conf.lock"
+SETUP_LOCKFILE="${CONF_LOCKFILE_DIR}/.postgresql.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then
 	return 0
 fi

--- a/scripts/setup-conf.sh
+++ b/scripts/setup-conf.sh
@@ -4,6 +4,7 @@ source /scripts/env-data.sh
 
 create_dir ${EXTRA_CONF_DIR}
 create_dir ${CONF_LOCKFILE_DIR}
+create_dir ${SCRIPTS_LOCKFILE_DIR}
 
 SETUP_LOCKFILE="${CONF_LOCKFILE_DIR}/.postgresql.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then

--- a/scripts/setup-conf.sh
+++ b/scripts/setup-conf.sh
@@ -2,7 +2,9 @@
 
 source /scripts/env-data.sh
 
-SETUP_LOCKFILE="${ROOT_CONF}/.postgresql.conf.lock"
+create_dir ${EXTRA_CONF_DIR}
+
+SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.postgresql.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then
 	return 0
 fi
@@ -76,9 +78,9 @@ echo "include 'streaming_replication.conf'" >> $CONF
 fi
 
 if [[ ! -f ${ROOT_CONF}/extra.conf ]]; then
-    # If it doesn't exists, copy from /settings directory if exists
-    if [[ -f /settings/extra.conf ]]; then
-      cp -f /settings/extra.conf ${ROOT_CONF}/extra.conf
+    # If it doesn't exists, copy from ${EXTRA_CONF_DIR} directory if exists
+    if [[ -f ${EXTRA_CONF_DIR}/extra.conf ]]; then
+      cp -f ${EXTRA_CONF_DIR}/extra.conf ${ROOT_CONF}/extra.conf
       echo "include 'extra.conf'" >> $CONF
     else
       # default value

--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -96,7 +96,7 @@ for db in $(echo ${POSTGRES_DBNAME} | tr ',' ' '); do
 done
 
 
-CRON_LOCKFILE="${ROOT_CONF}/.cron_ext.lock"
+CRON_LOCKFILE="${EXTRA_CONF_DIR}/.cron_ext.lock"
 if [ ! -f "${CRON_LOCKFILE}" ]; then
 	su - postgres -c "psql -c 'CREATE EXTENSION IF NOT EXISTS pg_cron cascade;' ${SINGLE_DB}"
 	touch ${CRON_LOCKFILE}

--- a/scripts/setup-pg_hba.sh
+++ b/scripts/setup-pg_hba.sh
@@ -2,7 +2,7 @@
 
 source /scripts/env-data.sh
 
-SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.pg_hba.conf.lock"
+SETUP_LOCKFILE="${CONF_LOCKFILE_DIR}/.pg_hba.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then
 	return 0
 fi

--- a/scripts/setup-pg_hba.sh
+++ b/scripts/setup-pg_hba.sh
@@ -2,7 +2,7 @@
 
 source /scripts/env-data.sh
 
-SETUP_LOCKFILE="${ROOT_CONF}/.pg_hba.conf.lock"
+SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.pg_hba.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then
 	return 0
 fi

--- a/scripts/setup-ssl.sh
+++ b/scripts/setup-ssl.sh
@@ -2,7 +2,7 @@
 
 source /scripts/env-data.sh
 
-SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.ssl.conf.lock"
+SETUP_LOCKFILE="${CONF_LOCKFILE_DIR}/.ssl.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then
 	return 0
 fi

--- a/scripts/setup-ssl.sh
+++ b/scripts/setup-ssl.sh
@@ -2,7 +2,7 @@
 
 source /scripts/env-data.sh
 
-SETUP_LOCKFILE="${ROOT_CONF}/.ssl.conf.lock"
+SETUP_LOCKFILE="${EXTRA_CONF_DIR}/.ssl.conf.lock"
 if [ -f "${SETUP_LOCKFILE}" ]; then
 	return 0
 fi


### PR DESCRIPTION
fixes https://github.com/kartoza/docker-postgis/issues/300

Did not want to mount these in the data directory because of the env variable ${RECREATE_DATADIR} which could clean up everything