### PR TITLE
Add ARM64 Build

### DIFF
--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -64,6 +64,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
           push: true
           tags: |
@@ -89,6 +90,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
           push: true
           tags: |


### PR DESCRIPTION
This adds an ARM64 build to the deploy-image action to enable running it natively on a M1 Mac (#301 ) .