### PR TITLE
Bug fix: kartoza/pg-backup:14.0 not available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       test: "exit 0"
 
   dbbackups:
-    image: kartoza/pg-backup:14.0
+    image: kartoza/pg-backup:14-3.1
     hostname: pg-backups
     volumes:
       - dbbackups:/backups


### PR DESCRIPTION
Changed to kartoza/pg-backup:14-3.1 to be consistent with version of db image (kartoza/postgis:14-3.1)