### PR TITLE
fix pg_hba

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "5432"
     restart: on-failure
     healthcheck:
-      test: "PGPASSWORD=${POSTGRES_PASS} pg_isready -h 127.0.0.1 -U ${POSTGRES_USER} -d ${POSTGRES_DB}"
+      test: "PGPASSWORD=docker pg_isready -h 127.0.0.1 -U docker -d gis"
 
   dbbackups:
     image: kartoza/pg-backup:15-3.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "5432"
     restart: on-failure
     healthcheck:
-      test: "exit 0"
+      test: "PGPASSWORD=${POSTGRES_PASS} pg_isready -h 127.0.0.1 -U ${POSTGRES_USER} -d ${POSTGRES_DB}"
 
   dbbackups:
     image: kartoza/pg-backup:15-3.3

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -418,7 +418,7 @@ function restart_postgres {
 function entry_point_script {
   SETUP_LOCKFILE="${SCRIPTS_LOCKFILE_DIR}/.entry_point.lock"
   # If lockfile doesn't exists, proceed.
-  if [[ ! -f "${SETUP_LOCKFILE}" ]] || [ "${IGNORE_INIT_HOOK_LOCKFILE}" =~ [Tt][Rr][Uu][Ee] ]; then
+  if [[ ! -f "${SETUP_LOCKFILE}" ]] || [[ "${IGNORE_INIT_HOOK_LOCKFILE}" =~ [Tt][Rr][Uu][Ee] ]]; then
       if find "/docker-entrypoint-initdb.d" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
           for f in /docker-entrypoint-initdb.d/*; do
           export PGPASSWORD=${POSTGRES_PASS}

--- a/scripts/setup-pg_hba.sh
+++ b/scripts/setup-pg_hba.sh
@@ -81,4 +81,6 @@ if [[ -z "$REPLICATE_FROM" ]]; then
 fi
 
 # Put lock file to make sure conf was not reinitialized
+export PASSWORD_AUTHENTICATION
+envsubst < $ROOT_CONF/pg_hba.conf > /tmp/pg_hba.conf && mv /tmp/pg_hba.conf $ROOT_CONF/pg_hba.conf
 touch ${SETUP_LOCKFILE}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,4 +7,12 @@ source /scripts/env-data.sh
 
 # Create backup template for conf
 cat $CONF > $CONF.template
+
+# Create backup template for pg_hba.conf
+sed -i 's/scram-sha-256/${PASSWORD_AUTHENTICATION}/g' $ROOT_CONF/pg_hba.conf
+sed -i 's/md5/${PASSWORD_AUTHENTICATION}/g' $ROOT_CONF/pg_hba.conf
+
+
 cat $ROOT_CONF/pg_hba.conf > $ROOT_CONF/pg_hba.conf.template
+
+


### PR DESCRIPTION
* Fix bug encountered when using the following
```
-v data-volume:/opt/postgres/data \
-e DATADIR:/opt/postgres/data \
-e PASSWORD_AUTHENTICATION=md5
```
In this case, pg_hba would have a mix of `md5` and `scram-sha-256` thereby preventing SQL scripts from running in entrypoint
