### PR TITLE
fix: also load pg_cron when timescale is enabled

### DIFF
--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -329,7 +329,7 @@ fi
 
 if [ -z "${SHARED_PRELOAD_LIBRARIES}" ]; then
     if [[ $(dpkg -l | grep "timescaledb") > /dev/null ]];then
-        SHARED_PRELOAD_LIBRARIES='timescaledb'
+        SHARED_PRELOAD_LIBRARIES='pg_cron,timescaledb'
     else
         SHARED_PRELOAD_LIBRARIES='pg_cron'
     fi


### PR DESCRIPTION
`pg_cron` was no longer in the list of the `SHARED_PRELOAD_LIBRARIES` when timescale is enabled which was causing an error when PG starts.