### PR TITLE
Feature/extension h3

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -9,7 +9,7 @@ on:
 #      imageVersion:
 #        description: Base distro image version/release
 #        required: true
-#        default: bullseye
+#        default: bookworm
 #      imageVariant:
 #        description: Base image variant
 #        required: true
@@ -41,7 +41,7 @@ jobs:
           - init_scripts
         include:
           - distro: debian
-            imageVersion: bullseye
+            imageVersion: bookworm
             imageVariant: slim
     steps:
       - uses: actions/checkout@v3
@@ -96,7 +96,7 @@ jobs:
           - 3
         include:
           - distro: debian
-            imageVersion: bullseye
+            imageVersion: bookworm
             imageVariant: slim
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -9,7 +9,7 @@ on:
 #      imageVersion:
 #        description: Base distro image version/release
 #        required: true
-#        default: bullseye
+#        default: bookworm
 #      imageVariant:
 #        description: Base image variant
 #        required: true
@@ -36,7 +36,7 @@ jobs:
           - 3
         include:
           - distro: debian
-            imageVersion: bullseye
+            imageVersion: bookworm
             imageVariant: slim
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,4 +171,4 @@ RUN set -eux \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install -r /lib/utils/requirements.txt
+RUN pip3 install -r /lib/utils/requirements.txt --break-system-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,17 @@ RUN if [ -z "${GENERATE_ALL_LOCALE}" ] || [ $GENERATE_ALL_LOCALE -eq 0 ]; \
 	&& /usr/sbin/locale-gen
 
 RUN update-locale ${LANG}
+
+# install pgxn client and update cmake to > 3.20 for h3 extension library
+RUN apt-get -y install pgxnclient
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh \
+      -q -O /tmp/cmake-install.sh \
+      && chmod u+x /tmp/cmake-install.sh \
+      && mkdir /opt/cmake-3.24.1 \
+      && /tmp/cmake-install.sh --skip-license --prefix=/opt/cmake-3.24.1 \
+      && rm /tmp/cmake-install.sh \
+      && ln -s /opt/cmake-3.24.1/bin/* /usr/local/bin
+
 # Cleanup resources
 RUN apt-get -y --purge autoremove  \
     && apt-get clean \
@@ -127,6 +138,9 @@ RUN wget -O- https://github.com/pgpointcloud/pointcloud/archive/master.tar.gz | 
 cd pointcloud-master && \
 ./autogen.sh && ./configure && make -j 4 && make install && \
 cd .. && rm -Rf pointcloud-master
+
+# install h3 library
+RUN pgxn install h3
 
 # Cleanup resources
 RUN apt-get -y --purge autoremove  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,13 @@ RUN set -eux \
     && apt-get update \
     && apt-get -y --no-install-recommends install \
         locales gnupg2 wget ca-certificates rpl pwgen software-properties-common  iputils-ping \
-        apt-transport-https curl gettext \
-    && dpkg-divert --local --rename --add /sbin/initctl
-
-RUN apt-get -y update; apt-get -y install build-essential autoconf  libxml2-dev zlib1g-dev netcat-openbsd gdal-bin \
+        apt-transport-https curl gettext pgxnclient cmake && \
+    apt-get -y install build-essential autoconf  libxml2-dev zlib1g-dev netcat-openbsd gdal-bin \
     figlet toilet gosu; \
     # verify that the binary works
-	gosu nobody true
+	gosu nobody true && \
+    dpkg-divert --local --rename --add /sbin/initctl
+
 
 # Generating locales takes a long time. Utilize caching by runnig it by itself
 # early in the build process.
@@ -57,15 +57,6 @@ RUN if [ -z "${GENERATE_ALL_LOCALE}" ] || [ $GENERATE_ALL_LOCALE -eq 0 ]; \
 
 RUN update-locale ${LANG}
 
-# install pgxn client and update cmake to > 3.20 for h3 extension library
-RUN apt-get -y install pgxnclient
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh \
-      -q -O /tmp/cmake-install.sh \
-      && chmod u+x /tmp/cmake-install.sh \
-      && mkdir /opt/cmake-3.24.1 \
-      && /tmp/cmake-install.sh --skip-license --prefix=/opt/cmake-3.24.1 \
-      && rm /tmp/cmake-install.sh \
-      && ln -s /opt/cmake-3.24.1/bin/* /usr/local/bin
 
 # Cleanup resources
 RUN apt-get -y --purge autoremove  \
@@ -116,7 +107,8 @@ RUN set -eux \
         postgresql-${POSTGRES_MAJOR_VERSION}-postgis-${POSTGIS_MAJOR_VERSION}-scripts \
         postgresql-plpython3-${POSTGRES_MAJOR_VERSION} postgresql-${POSTGRES_MAJOR_VERSION}-pgrouting \
         postgresql-server-dev-${POSTGRES_MAJOR_VERSION}  postgresql-${POSTGRES_MAJOR_VERSION}-cron \
-        postgresql-${POSTGRES_MAJOR_VERSION}-mysql-fdw
+        postgresql-${POSTGRES_MAJOR_VERSION}-mysql-fdw && \
+        pgxn install h3
 
 # TODO a case insensitive match would be more robust
 RUN if [ "${BUILD_TIMESCALE}" = "true" ]; then \
@@ -139,8 +131,7 @@ cd pointcloud-master && \
 ./autogen.sh && ./configure && make -j 4 && make install && \
 cd .. && rm -Rf pointcloud-master
 
-# install h3 library
-RUN pgxn install h3
+
 
 # Cleanup resources
 RUN apt-get -y --purge autoremove  \

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -277,9 +277,9 @@ function postgres_ssl_setup() {
 
 if [ -z "${POSTGRES_MULTIPLE_EXTENSIONS}" ]; then
     if [[ $(dpkg -l | grep "timescaledb") > /dev/null ]];then
-        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting,timescaledb'
+        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting,h3,h3_postgis,timescaledb'
     else
-        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting'
+        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting,h3,h3_postgis'
     fi
 fi
 

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -278,9 +278,9 @@ function postgres_ssl_setup() {
 
 if [ -z "${POSTGRES_MULTIPLE_EXTENSIONS}" ]; then
     if [[ $(dpkg -l | grep "timescaledb") > /dev/null ]];then
-        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting,h3,h3_postgis,timescaledb'
+        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting,timescaledb'
     else
-        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting,h3,h3_postgis'
+        POSTGRES_MULTIPLE_EXTENSIONS='postgis,hstore,postgis_topology,postgis_raster,pgrouting'
     fi
 fi
 


### PR DESCRIPTION
Based on this tutorial 

https://blog.rustprooflabs.com/2023/05/postgis-h3-v4-refresh
and previous
https://blog.rustprooflabs.com/2022/04/postgis-h3-intro

I added to my local image the h3 extension for Uber-h3 cells postgis functions. 

Which depends on 

https://github.com/zachasme/h3-pg

the library installation needs pgxn client and make > 3.20 installed so I modified the docker file accordingly.

Do you think it will be possible to include this library in the develop and next release of available docker images? 

I already tested it in local adding the extension to the env var:

      - POSTGRES_MULTIPLE_EXTENSIONS=postgis,hstore,postgis_topology,postgis_raster,pgrouting,h3,h3_postgis

and it works.

you can test it running the following query once container is up:

SELECT extname, extversion
    FROM pg_catalog.pg_extension 
    WHERE extname IN ('h3', 'h3_postgis')
;