### PR TITLE
Better handling of signals from docker kill by launching postgres as PID 1.

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -88,7 +88,7 @@ if [[ $# -eq 0 ]];then
   if [[ ${RUN_AS_ROOT} =~ [Tt][Rr][Uu][Ee] ]];then
     echo -e "[Entrypoint] \e[1;31m Postgres initialisation process completed .... restarting in foreground \033[0m"
     non_root_permission postgres postgres
-    su - postgres -c "$SETVARS $POSTGRES -D $DATADIR -c config_file=$CONF"
+    exec su - postgres -c "$SETVARS $POSTGRES -D $DATADIR -c config_file=$CONF"
   else
     echo -e "[Entrypoint] \e[1;31m Postgres initialisation process completed .... restarting in foreground with gosu \033[0m"
     non_root_permission "${USER_NAME}" "${DB_GROUP_NAME}"


### PR DESCRIPTION
In the case we launched the container without arguments as non root, the postgres process was not launched using exec.
This lead to docker kill or docker compose down to be slow. 