### PR TITLE
Improve documentation of startup behaviour.

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,12 +514,14 @@ In some instances users want to run some SQL scripts to populate the database. T
 variable `POSTGRES_DB` allows us to specify multiple database that can be created on startup. When
 running scripts they will only be executed against the first database ie
 `POSTGRES_DB=gis,data,sample`. The SQL script will be executed against the `gis` database.
+
+The database will start accepting connection only after the script will have been executed.
+
 Additionally, a lock file is generated in `/docker-entrypoint-initdb.d`, which will prevent the
 scripts from getting executed after the first container startup. Provide
-`IGNORE_INIT_HOOK_LOCKFILE=true` to execute the scripts on _every_ container start.
-
-By default, the lockfile is generated in `/docker-entrypoint-initdb.d` but it can be overwritten by
- passing the environment variable `SCRIPTS_LOCKFILE_DIR` which can point to another location i.e
+`IGNORE_INIT_HOOK_LOCKFILE=true` to execute the scripts on _every_ container start. By default, the
+lockfile is generated in `/docker-entrypoint-initdb.d` but it can be overwritten by
+passing the environment variable `SCRIPTS_LOCKFILE_DIR` which can point to another location i.e
 
  ```shell
  -e SCRIPTS_LOCKFILE_DIR=/data/ \


### PR DESCRIPTION
As per https://github.com/kartoza/docker-postgis/issues/475 when populating the databse via docker-entrypoint-initdb.d there is a theoretical race condition where pg_isready claims the database is ready while the scripts have not finished running yet. This race condition does not actually exist because at that stage the database only listens on Unix socket and 127.0.0.1. After the script execution completes, it is restarted and made to listen on 0.0.0.0 and ::.

This change documents this behaviour so that users can rely on it.

Example log:
```
└→> $ docker logs [container]
Add rule to pg_hba: 0.0.0.0/0
Add rule to pg_hba: replication replicator 
Setup master database
Creating /opt/archivedir directory
2024-06-20 13:01:14.224 UTC [57] LOG:  starting PostgreSQL 13.1 (Debian 13.1-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
2024-06-20 13:01:14.225 UTC [57] LOG:  listening on IPv4 address "127.0.0.1", port 5432
2024-06-20 13:01:14.233 UTC [57] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2024-06-20 13:01:14.251 UTC [61] LOG:  database system was shut down at 2020-11-14 12:13:00 UTC
2024-06-20 13:01:14.268 UTC [57] LOG:  database system is ready to accept connections
2024-06-20 13:01:14.272 UTC [67] FATAL:  database "[name]" does not exist
2024-06-20 13:01:14.285 UTC [57] LOG:  background worker "pg_cron launcher" (PID 67) exited with exit code 1
/var/run/postgresql:5432 - accepting connections
postgres ready
Setup postgres User:Password
Creating superuser [user]
CREATE ROLE
Creating replication user replicator
CREATE ROLE
Create db [database]
Enabling postgis in the database [database]
2024-06-20 13:01:15.288 UTC [170] LOG:  pg_cron scheduler started
CREATE EXTENSION
Enabling hstore in the database [database]
CREATE EXTENSION
Enabling postgis_topology in the database [database]
CREATE EXTENSION
Enabling postgis_raster in the database [database]
CREATE EXTENSION
Enabling pgrouting in the database [database]
CREATE EXTENSION
Loading legacy sql
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
CREATE OPERATOR CLASS
ALTER DEFAULT PRIVILEGES
CREATE EXTENSION
[...]
2024-06-20 13:01:17.282 UTC [57] LOG:  received smart shutdown request
/var/run/postgresql/13-main.pid
2024-06-20 13:01:17.284 UTC [170] LOG:  pg_cron scheduler shutting down
2024-06-20 13:01:17.286 UTC [57] LOG:  background worker "logical replication launcher" (PID 68) exited with exit code 1
2024-06-20 13:01:17.288 UTC [62] LOG:  shutting down
2024-06-20 13:01:17.351 UTC [57] LOG:  database system is shut down
Postgres initialisation process completed .... restarting in foreground
2024-06-20 13:01:18.346 UTC [303] LOG:  starting PostgreSQL 13.1 (Debian 13.1-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
2024-06-20 13:01:18.346 UTC [303] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2024-06-20 13:01:18.347 UTC [303] LOG:  listening on IPv6 address "::", port 5432
2024-06-20 13:01:18.351 UTC [303] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2024-06-20 13:01:18.357 UTC [305] LOG:  database system was shut down at 2024-06-20 13:01:17 UTC
2024-06-20 13:01:18.365 UTC [303] LOG:  database system is ready to accept connections
2024-06-20 13:01:18.373 UTC [311] LOG:  pg_cron scheduler started
```