### PR TITLE
Add plperl plperlu extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,8 @@ RUN set -eux \
         postgresql-${POSTGRES_MAJOR_VERSION}-postgis-${POSTGIS_MAJOR_VERSION}-scripts \
         postgresql-plpython3-${POSTGRES_MAJOR_VERSION} postgresql-${POSTGRES_MAJOR_VERSION}-pgrouting \
         postgresql-server-dev-${POSTGRES_MAJOR_VERSION}  postgresql-${POSTGRES_MAJOR_VERSION}-cron \
-        postgresql-${POSTGRES_MAJOR_VERSION}-mysql-fdw && \
+        postgresql-${POSTGRES_MAJOR_VERSION}-mysql-fdw \
+        postgresql-plperl-${POSTGRES_MAJOR_VERSION} && \
         pgxn install h3
 
 # TODO a case insensitive match would be more robust


### PR DESCRIPTION
Hello,

This PR is initiated from the comment of a closed issue: https://github.com/kartoza/docker-postgis/issues/478

It adds the the possibility to add plperl and plperlu extensions. They are not activated by default so I didn't update the README in this PR. I hope everythin will be ok for you.

