### PR TITLE
allow tagging specific versions

### DIFF
--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -8,16 +8,17 @@ on:
       - develop
     types:
       - completed
+
 jobs:
-  deploy-image:
+  build-local_image:
     runs-on: ubuntu-latest
-    #timeout-minutes: 30
     if: |
       github.actor != 'dependabot[bot]' &&
       !(
         contains(github.event.pull_request.title, '[skip-release]') ||
         contains(github.event.comment.body, '/skiprelease')
-      ) && github.event.workflow_run.conclusion == 'success'
+      ) &&
+      github.event.workflow_run.conclusion == 'success'
     env:
       latest-ref: refs/heads/develop
     strategy:
@@ -32,30 +33,108 @@ jobs:
           - imageDistro: debian
             imageDistroVersion: trixie
             imageDistroVariant: slim
+
     steps:
       - uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      - name: Build prod local run image
+        id: docker_build_local_run
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: kartoza/postgis:prod-build
+          outputs: type=docker,dest=/tmp/postgis.tar
+          build-args: |
+            DISTRO=${{ matrix.imageVersion.imageDistro }}
+            IMAGE_VERSION=${{ matrix.imageVersion.imageDistroVersion }}
+            IMAGE_VARIANT=${{ matrix.imageVersion.imageDistroVariant }}
+            GENERATE_ALL_LOCALE=0
+            POSTGRES_MAJOR_VERSION=${{ matrix.postgresMajorVersion }}
+            POSTGIS_MAJOR_VERSION=${{ matrix.postgisMajorVersion }}
+            POSTGIS_MINOR_VERSION=${{ matrix.postgisMinorRelease }}
+          cache-from: |
+            type=gha,scope=prod
+          target: postgis-prod
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: kartoza-postgis
+          path: /tmp/postgis.tar
 
+  extract-pg-params:
+    runs-on: ubuntu-latest
+    needs:
+      - build-local_image
+    timeout-minutes: 20
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') &&
+      github.actor != 'dependabot[bot]' &&
+      !(
+        contains(github.event.pull_request.title, '[skip-release]') ||
+        contains(github.event.comment.body, '/skiprelease')
+      )
+    strategy:
+      matrix:
+        postgresMajorVersion:
+          - 18
+        postgisMajorVersion:
+          - 3
+        postgisMinorRelease:
+          - 6
+        postgisPatchMajorVersionBugs:
+          - no
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: kartoza-postgis
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/postgis.tar
+      - name: Get image versions
+        id: pg_image_versions
+        run: |
+          PG_VER=$(docker run --rm \
+            kartoza/postgis:prod-build \
+            bash -c "apt-cache policy postgresql-${{ matrix.postgresMajorVersion }} \
+              | awk '/Candidate:/ {print \$2}' \
+              | sed 's/-.*//'")
+          GIS_VER=$(docker run --rm \
+            kartoza/postgis:prod-build \
+            bash -c "apt-cache policy postgresql-${{ matrix.postgresMajorVersion }}-postgis-${{ matrix.postgisMajorVersion }} \
+              | awk '/Candidate:/ {print \$2}' \
+              | sed 's/+.*//' \
+              | sed 's/-.*//'")
+          echo "PG_VER=${PG_VER}" >> $GITHUB_OUTPUT
+          echo "GIS_VER=${GIS_VER}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
+      - name: Check if generic image tag exists
+        id: check_generic_tag
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          https://hub.docker.com/v2/repositories/kartoza/postgis/tags/${{ matrix.postgresMajorVersion }}-${{ matrix.postgisMajorVersion }}.${{ matrix.postgisMinorRelease }}/)
+          echo "check_generic_image=${STATUS}" >> $GITHUB_OUTPUT
+      - name: Check if exact image tag exists
+        id: check_exact_tag
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          https://hub.docker.com/v2/repositories/kartoza/postgis/tags/${{ steps.pg_image_versions.outputs.PG_VER }}-${{ steps.pg_image_versions.outputs.GIS_VER }}/)
+          echo "check_exact_image=${STATUS}" >> $GITHUB_OUTPUT
       - name: Get Current Date
         id: current_date
         run: echo "formatted=$(date -u +%Y.%m.%d)" >> $GITHUB_OUTPUT
-
-      - name: Check if image exists on Docker Hub
-        id: check_hub_image_exists
-        run: |
-          docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_PASSWORD }}
-          TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${{ secrets.DOCKERHUB_USERNAME }}'", "password": "'${{ secrets.DOCKERHUB_PASSWORD }}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          check_image=$(curl --silent -f --head -lL https://hub.docker.com/v2/repositories/kartoza/postgis/tags/${{ matrix.postgresMajorVersion }}-${{ matrix.postgisMajorVersion }}.${{ matrix.postgisMinorRelease }}/ | head -n 1 | cut -d ' ' -f2) >> $GITHUB_OUTPUT
-
       - name: Build prod image
         id: docker_build_prod
         uses: docker/build-push-action@v7
@@ -66,9 +145,14 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_REPO }}/postgis
-            ${{ steps.check_hub_image_exists.outputs.check_image == 200 && format('{0}/postgis:{1}-{2}.{3}', secrets.DOCKERHUB_REPO,  matrix.postgresMajorVersion, matrix.postgisMajorVersion, matrix.postgisMinorRelease) || null}}
-            ${{ secrets.DOCKERHUB_REPO }}/postgis:${{ matrix.postgresMajorVersion }}-${{ matrix.postgisMajorVersion }}.${{ matrix.postgisMinorRelease }}
+
+            ${{ (steps.check_generic_tag.outputs.check_generic_image == '404' || env.postgisPatchMajorVersionBugs == 'yes') && format('{0}/postgis:{1}-{2}.{3}', secrets.DOCKERHUB_REPO, matrix.postgresMajorVersion, matrix.postgisMajorVersion, matrix.postgisMinorRelease) || null }}
+
+            ${{ (steps.check_exact_tag.outputs.check_exact_image == '404' || env.postgisPatchMajorVersionBugs == 'yes') && format('{0}/postgis:{1}-{2}', secrets.DOCKERHUB_REPO, steps.pg_image_versions.outputs.PG_VER, steps.pg_image_versions.outputs.GIS_VER) || null }}
+
             ${{ secrets.DOCKERHUB_REPO }}/postgis:${{ matrix.postgresMajorVersion }}-${{ matrix.postgisMajorVersion }}.${{ matrix.postgisMinorRelease }}--v${{ steps.current_date.outputs.formatted }}
+
+            ${{ secrets.DOCKERHUB_REPO }}/postgis:${{ steps.pg_image_versions.outputs.PG_VER }}-${{ steps.pg_image_versions.outputs.GIS_VER }}--v${{ steps.current_date.outputs.formatted }}
           build-args: |
             DISTRO=${{ matrix.imageVersion.imageDistro }}
             IMAGE_VERSION=${{ matrix.imageVersion.imageDistroVersion }}
@@ -79,7 +163,6 @@ jobs:
             POSTGIS_MINOR_VERSION=${{ matrix.postgisMinorRelease }}
           cache-from: |
             type=gha,scope=prod
-          #cache-to: type=gha,scope=prod
           target: postgis-prod
 
   publish_release_artifacts:
@@ -89,9 +172,9 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       !(
         contains(github.event.pull_request.title, '[skip-release]') ||
-        contains(github.event.comment.body, '/skiprelease') 
+        contains(github.event.comment.body, '/skiprelease')
       ) &&  github.event.workflow_run.conclusion == 'success'
-    needs: [ deploy-image ]
+    needs: [build-local_image]
     strategy:
       matrix:
         postgresMajorVersion:
@@ -106,15 +189,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: 'develop'
-
       - name: Get Current Date
         id: current_date
         run: echo "formatted=$(date -u +%Y.%m.%d)" >> $GITHUB_OUTPUT
-
       - name: Get Latest Commit Hash
         id: latest_commit_hash
         run: echo "commit=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
-
       - name: publish_release
         id: tag_releases
         run: |

--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -102,17 +102,26 @@ jobs:
       - name: Get image versions
         id: pg_image_versions
         run: |
-          PG_VER=$(docker run --rm \
-            kartoza/postgis:prod-build \
-            bash -c "apt-cache policy postgresql-${{ matrix.postgresMajorVersion }} \
-              | awk '/Candidate:/ {print \$2}' \
-              | sed 's/-.*//'")
-          GIS_VER=$(docker run --rm \
-            kartoza/postgis:prod-build \
-            bash -c "apt-cache policy postgresql-${{ matrix.postgresMajorVersion }}-postgis-${{ matrix.postgisMajorVersion }} \
-              | awk '/Candidate:/ {print \$2}' \
-              | sed 's/+.*//' \
-              | sed 's/-.*//'")
+          CONTAINER_NAME=postgis-version-check
+
+          docker run -d \
+            --name ${CONTAINER_NAME} \
+            kartoza/postgis:prod-build 
+
+          PG_VER=$(docker exec ${CONTAINER_NAME} bash -c \
+            "apt-cache policy postgresql-${{ matrix.postgresMajorVersion }} \
+            | awk '/Candidate:/ {print \$2}' \
+            | sed 's/-.*//'")
+
+          GIS_VER=$(docker exec ${CONTAINER_NAME} bash -c \
+            "apt-cache policy postgresql-${{ matrix.postgresMajorVersion }}-postgis-${{ matrix.postgisMajorVersion }} \
+            | awk '/Candidate:/ {print \$2}' \
+            | sed 's/+.*//' \
+            | sed 's/-.*//'")
+
+          docker stop ${CONTAINER_NAME}
+          docker rm ${CONTAINER_NAME}
+
           echo "PG_VER=${PG_VER}" >> $GITHUB_OUTPUT
           echo "GIS_VER=${GIS_VER}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub


### PR DESCRIPTION
Allow tagging specific versions i.e .

```
kartoza/postgis (tags latest always)

kartoza/postgis:18-3.6 (only if missing OR overwrite=yes)

kartoza/postgis:18.3-3.6.3 (only if missing OR overwrite=yes)

kartoza/postgis:18-3.6--v2026.03.24 (dated generic tag)

kartoza/postgis:18.3-3.6.3--v2026.03.24 (dated exact tag)

````

Allows us to check what version of PostGIS and PostgreSQL are installed
i.e before we would have
`18` now we would have `18.3`
`3.6` now we would have `3.6.3`
Now these vars are extracted from a built image